### PR TITLE
Add sensors to show current and accumulated gas usage

### DIFF
--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -71,7 +71,7 @@ bool Navien::seek_to_marker(){
 void Navien::parse_water(){
   ESP_LOGV(TAG, "Got Water Packet => %d bytes", this->recv_buffer.hdr.len + HDR_SIZE);
   //Navien::print_buffer(this->recv_buffer.raw_data, this->recv_buffer.hdr.len + HDR_SIZE);
-
+      
   ESP_LOGV(TAG, "Received Temp: 0x%02X, Inlet: 0x%02X, Outlet: 0x%02X, Flow: 0x%02X",
 	   this->recv_buffer.water.set_temp,
 	   this->recv_buffer.water.inlet_temp,

--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -71,7 +71,7 @@ bool Navien::seek_to_marker(){
 void Navien::parse_water(){
   ESP_LOGV(TAG, "Got Water Packet => %d bytes", this->recv_buffer.hdr.len + HDR_SIZE);
   //Navien::print_buffer(this->recv_buffer.raw_data, this->recv_buffer.hdr.len + HDR_SIZE);
-      
+
   ESP_LOGV(TAG, "Received Temp: 0x%02X, Inlet: 0x%02X, Outlet: 0x%02X, Flow: 0x%02X",
 	   this->recv_buffer.water.set_temp,
 	   this->recv_buffer.water.inlet_temp,

--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -11,15 +11,6 @@ namespace navien {
 static const char *TAG = "navien.sensor";
 
 void Navien::setup() {
-  ESP_LOGCONFIG(TAG, "Setting rs485 into receive mode");
-  // Set the rs485 into receive mode
-  pinMode(D5, OUTPUT);
-  digitalWrite(D5, LOW);
-
-  // Set the driver into regular mode (from undefined startup)
-  ESP_LOGCONFIG(TAG, "Activating TTL/CMOS buffer");
-  pinMode(D6, OUTPUT);
-  digitalWrite(D6, HIGH);
 }
 
 void Navien::update() {
@@ -163,7 +154,7 @@ void Navien::parse_packet(){
     break;
   }
 
-  //  ESP_LOGV(TAG, "Calculated checksum over %d bytes => 0x%02X", HDR_SIZE + this->recv_buffer.hdr.len, crc);
+  //  ESP_LOGV(TAG, "Calculated checksum over %d bytes => 0x%02X", HDR_SIZE + this->recv_buffer.hdr.len, crc_c);
 
 }
 
@@ -223,7 +214,7 @@ void Navien::loop() {
   }
 }
 
-void Navien::send_cmd(const uint8_t * buffer, uint8 len){
+void Navien::send_cmd(const uint8_t * buffer, uint8_t len){
   if (buffer && len)
     this->write_array(buffer, len);
 }
@@ -316,6 +307,7 @@ uint8_t Navien::checksum(const uint8_t * buffer, uint8_t len, uint16_t seed){
   return result;
 }
 
+#ifdef USE_SWITCH
 void NavienOnOffSwitch::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Switch '%s'...", this->name_.c_str());
 
@@ -344,6 +336,7 @@ void NavienOnOffSwitch::write_state(bool state) {
 void NavienOnOffSwitch::dump_config(){
     ESP_LOGCONFIG(TAG, "Empty custom switch");
 }
+#endif
   
 }  // namespace navien
 }  // namespace esphome

--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -53,6 +53,7 @@ void Navien::update() {
   if (this->water_flow_sensor != nullptr)
     this->water_flow_sensor->publish_state(this->state.water.flow_lpm);
 
+#ifdef USE_SWITCH
   if (this->power_switch != nullptr){
     switch(this->state.power){
     case POWER_ON:
@@ -62,6 +63,7 @@ void Navien::update() {
       this->power_switch->publish_state(false);
     }
   }
+#endif
 }
 
 bool Navien::seek_to_marker(){
@@ -103,7 +105,7 @@ void Navien::parse_water(){
   
   this->state.water.flow_lpm = Navien::flow2lpm(this->recv_buffer.water.water_flow);
 
-  uint8 power = this->recv_buffer.water.system_power;
+  uint8_t power = this->recv_buffer.water.system_power;
   if (power & POWER_STATUS_ON_OFF_MASK)
     this->state.power = POWER_ON;
   else
@@ -420,6 +422,7 @@ void NavienOnOffSwitch::dump_config(){
 #endif
 
 
+#ifdef USE_BUTTON
 void NavienHotButton::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Button '%s'...", this->name_.c_str());
 }
@@ -436,6 +439,7 @@ void NavienHotButton::set_parent(Navien * parent) {
 void NavienHotButton::dump_config(){
     ESP_LOGCONFIG(TAG, "Navien Hot Button");
 }
+#endif
   
 }  // namespace navien
 }  // namespace esphome

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -202,10 +202,11 @@ typedef struct _NAVIEN_CMD{
   _NAVIEN_CMD(const uint8_t * b, uint8_t l): buffer(b), len(l) {}
 } NAVIEN_CMD;
   
-class Navien : public Component, public uart::UARTDevice {
+class Navien : public PollingComponent, public uart::UARTDevice {
 public:
   virtual float get_setup_priority() const { return setup_priority::HARDWARE; }
   virtual void setup() override;
+  void update() override;
   void loop() override;
   void dump_config() override;
 
@@ -276,6 +277,10 @@ protected:
   RECV_BUFFER  recv_buffer;
   //uint8_t      recv_ptr;
   //bool         found_marker;
+
+  // Data, extracted from gas and water packers and stored
+  // Once the "update" is called this data gets reported to readers.
+  NAVIEN_STATE state;
 
   // How many packets were received
   uint32_t received_cnt;

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -202,10 +202,11 @@ typedef struct _NAVIEN_CMD{
   _NAVIEN_CMD(const uint8_t * b, uint8_t l): buffer(b), len(l) {}
 } NAVIEN_CMD;
   
-class Navien : public Component, public uart::UARTDevice {
+class Navien : public PollingComponent, public uart::UARTDevice {
 public:
   virtual float get_setup_priority() const { return setup_priority::HARDWARE; }
   virtual void setup() override;
+  void update() override;
   void loop() override;
   void dump_config() override;
 
@@ -275,6 +276,10 @@ protected:
   RECV_BUFFER  recv_buffer;
   //uint8_t      recv_ptr;
   //bool         found_marker;
+
+  // Data, extracted from gas and water packers and stored
+  // Once the "update" is called this data gets reported to readers.
+  NAVIEN_STATE state;
 
   // How many packets were received
   uint32_t received_cnt;

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -312,7 +312,9 @@ public:
   void set_outlet_temp_sensor(sensor::Sensor *sensor) { outlet_temp_sensor = sensor; }
   void set_water_flow_sensor(sensor::Sensor *sensor) { water_flow_sensor = sensor; }
 
+#ifdef USE_SWITCH
   void set_power_switch(switch_::Switch * ps){power_switch = ps;}
+#endif
 protected:
   /**
    * Sensor definitions
@@ -322,7 +324,9 @@ protected:
   sensor::Sensor *inlet_temp_sensor;
   sensor::Sensor *water_flow_sensor;
 
+#ifdef USE_SWITCH
   switch_::Switch *power_switch;
+#endif
 };
 
 #ifdef USE_SWITCH
@@ -338,6 +342,7 @@ class NavienOnOffSwitch : public switch_::Switch, public Component {
 };
 #endif
 
+#ifdef USE_BUTTON
 class NavienHotButton : public button::Button, public Component {
     protected:
       Navien * parent;
@@ -349,6 +354,7 @@ class NavienHotButton : public button::Button, public Component {
       void press_action() override;
       void dump_config() override;
 };
+#endif
     
 }  // namespace navien
 }  // namespace esphome

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -185,20 +185,6 @@ typedef enum _DEVICE_POWER_STATE{
 } DEVICE_POWER_STATE;
   
 typedef struct{
-  struct{
-    uint8_t set_temp;
-    uint8_t outlet_temp;
-    uint8_t inlet_temp;
-    float flow_lpm;
-  } water;
-  struct{
-    uint8_t  set_temp;
-    uint8_t  outlet_temp;
-    uint8_t  inlet_temp;
-    uint16_t accumulated_gas_usage;
-    uint16_t current_gas_usage;
-  } gas;
-
   uint16_t           controller_version;
   uint16_t           panel_version;
   DEVICE_POWER_STATE power;
@@ -216,11 +202,10 @@ typedef struct _NAVIEN_CMD{
   _NAVIEN_CMD(const uint8_t * b, uint8_t l): buffer(b), len(l) {}
 } NAVIEN_CMD;
   
-class Navien : public PollingComponent, public uart::UARTDevice {
+class Navien : public Component, public uart::UARTDevice {
 public:
   virtual float get_setup_priority() const { return setup_priority::HARDWARE; }
   virtual void setup() override;
-  void update() override;
   void loop() override;
   void dump_config() override;
 
@@ -290,10 +275,6 @@ protected:
   RECV_BUFFER  recv_buffer;
   //uint8_t      recv_ptr;
   //bool         found_marker;
-
-  // Data, extracted from gas and water packers and stored
-  // Once the "update" is called this data gets reported to readers.
-  NAVIEN_STATE state;
 
   // How many packets were received
   uint32_t received_cnt;

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -2,6 +2,9 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
+#ifdef USE_SWITCH
+#include "esphome/components/switch/switch.h"
+#endif
 #include "esphome/components/uart/uart.h"
 
 namespace esphome {
@@ -226,7 +229,7 @@ public:
   void send_turn_off_cmd();
   
 protected:
-  void send_cmd(const uint8_t * buffer, uint8 len);
+  void send_cmd(const uint8_t * buffer, uint8_t len);
   
 protected:
   // Keeps track of the state machine and iterates through
@@ -259,6 +262,7 @@ protected:
   sensor::Sensor *water_flow_sensor;
 };
 
+#ifdef USE_SWITCH
 class NavienOnOffSwitch : public switch_::Switch, public Component {
     protected:
       Navien * parent;
@@ -269,6 +273,7 @@ class NavienOnOffSwitch : public switch_::Switch, public Component {
       void write_state(bool state) override;
       void dump_config() override;
 };
-    
+#endif
+
 }  // namespace navien
 }  // namespace esphome

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -218,6 +218,7 @@ protected:
   static float flow2gpm(uint8_t f);
   static uint8_t t2c(uint8_t);
   static float flow2lpm(uint8_t f);
+  static float usage2cum(uint16_t f);
 
   /**
    * 
@@ -292,6 +293,8 @@ public:
   void set_inlet_temp_sensor(sensor::Sensor *sensor) { inlet_temp_sensor = sensor; }
   void set_outlet_temp_sensor(sensor::Sensor *sensor) { outlet_temp_sensor = sensor; }
   void set_water_flow_sensor(sensor::Sensor *sensor) { water_flow_sensor = sensor; }
+  void set_current_gas_sensor(sensor::Sensor *sensor) { current_gas_sensor = sensor; }
+  void set_accumulated_gas_sensor(sensor::Sensor *sensor) { accumulated_gas_sensor = sensor; }
 
 #ifdef USE_SWITCH
   void set_power_switch(switch_::Switch * ps){power_switch = ps;}
@@ -300,10 +303,12 @@ protected:
   /**
    * Sensor definitions
    */
-  sensor::Sensor *target_temp_sensor;
-  sensor::Sensor *outlet_temp_sensor;
-  sensor::Sensor *inlet_temp_sensor;
-  sensor::Sensor *water_flow_sensor;
+  sensor::Sensor *target_temp_sensor = nullptr;
+  sensor::Sensor *outlet_temp_sensor = nullptr;
+  sensor::Sensor *inlet_temp_sensor = nullptr;
+  sensor::Sensor *water_flow_sensor = nullptr;
+  sensor::Sensor *current_gas_sensor = nullptr;
+  sensor::Sensor *accumulated_gas_sensor = nullptr;
 
 #ifdef USE_SWITCH
   switch_::Switch *power_switch;

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -202,11 +202,10 @@ typedef struct _NAVIEN_CMD{
   _NAVIEN_CMD(const uint8_t * b, uint8_t l): buffer(b), len(l) {}
 } NAVIEN_CMD;
   
-class Navien : public PollingComponent, public uart::UARTDevice {
+class Navien : public Component, public uart::UARTDevice {
 public:
   virtual float get_setup_priority() const { return setup_priority::HARDWARE; }
   virtual void setup() override;
-  void update() override;
   void loop() override;
   void dump_config() override;
 
@@ -276,10 +275,6 @@ protected:
   RECV_BUFFER  recv_buffer;
   //uint8_t      recv_ptr;
   //bool         found_marker;
-
-  // Data, extracted from gas and water packers and stored
-  // Once the "update" is called this data gets reported to readers.
-  NAVIEN_STATE state;
 
   // How many packets were received
   uint32_t received_cnt;

--- a/esphome/components/navien/sensor.py
+++ b/esphome/components/navien/sensor.py
@@ -15,7 +15,7 @@ NAVIEN_CONFIG_ID = "navien"
 
 navien_ns = cg.esphome_ns.namespace(NAVIEN_NAMESPACE)
 
-Navien = navien_ns.class_("Navien", cg.Component, uart.UARTDevice)
+Navien = navien_ns.class_("Navien", cg.PollingComponent, uart.UARTDevice)
 print ("Hello compojnents navien - imported")
 
 
@@ -36,6 +36,7 @@ from esphome.const import (
 
 #CONFIG_SCHEMA = (
 #    sensor.sensor_schema(Navien, unit_of_measurement=UNIT_EMPTY, icon=ICON_EMPTY, accuracy_decimals=1,)
+#    .extend(cv.polling_component_schema("60s"))
 #    .extend(uart.UART_DEVICE_SCHEMA)
 #)
 
@@ -84,6 +85,7 @@ CONFIG_SCHEMA = cv.All(
             ),
         }
     )
+    .extend(cv.polling_component_schema("5s"))
     .extend(uart.UART_DEVICE_SCHEMA)
 )
 

--- a/esphome/components/navien/sensor.py
+++ b/esphome/components/navien/sensor.py
@@ -15,7 +15,7 @@ NAVIEN_CONFIG_ID = "navien"
 
 navien_ns = cg.esphome_ns.namespace(NAVIEN_NAMESPACE)
 
-Navien = navien_ns.class_("Navien", cg.PollingComponent, uart.UARTDevice)
+Navien = navien_ns.class_("Navien", cg.Component, uart.UARTDevice)
 print ("Hello compojnents navien - imported")
 
 
@@ -36,7 +36,6 @@ from esphome.const import (
 
 #CONFIG_SCHEMA = (
 #    sensor.sensor_schema(Navien, unit_of_measurement=UNIT_EMPTY, icon=ICON_EMPTY, accuracy_decimals=1,)
-#    .extend(cv.polling_component_schema("60s"))
 #    .extend(uart.UART_DEVICE_SCHEMA)
 #)
 
@@ -73,7 +72,6 @@ CONFIG_SCHEMA = cv.All(
             ),
         }
     )
-    .extend(cv.polling_component_schema("5s"))
     .extend(uart.UART_DEVICE_SCHEMA)
 )
 

--- a/esphome/components/navien/sensor.py
+++ b/esphome/components/navien/sensor.py
@@ -15,7 +15,7 @@ NAVIEN_CONFIG_ID = "navien"
 
 navien_ns = cg.esphome_ns.namespace(NAVIEN_NAMESPACE)
 
-Navien = navien_ns.class_("Navien", cg.Component, uart.UARTDevice)
+Navien = navien_ns.class_("Navien", cg.PollingComponent, uart.UARTDevice)
 print ("Hello compojnents navien - imported")
 
 
@@ -36,6 +36,7 @@ from esphome.const import (
 
 #CONFIG_SCHEMA = (
 #    sensor.sensor_schema(Navien, unit_of_measurement=UNIT_EMPTY, icon=ICON_EMPTY, accuracy_decimals=1,)
+#    .extend(cv.polling_component_schema("60s"))
 #    .extend(uart.UART_DEVICE_SCHEMA)
 #)
 
@@ -72,6 +73,7 @@ CONFIG_SCHEMA = cv.All(
             ),
         }
     )
+    .extend(cv.polling_component_schema("5s"))
     .extend(uart.UART_DEVICE_SCHEMA)
 )
 

--- a/esphome/components/navien/sensor.py
+++ b/esphome/components/navien/sensor.py
@@ -40,10 +40,14 @@ from esphome.const import (
 #)
 
 UNIT_LPM = "l/m"
+UNIT_KILOCALORIE = "kcal"
+UNIT_CUBIC_METERS = "m^3"
 
 CONF_INLET_TEMPERATURE  = "inlet_temperature"
 CONF_OUTLET_TEMPERATURE = "outlet_temperature"
 CONF_WATER_FLOW         = "water_flow"
+CONF_CURRENT_GAS_USAGE      = "current_gas_usage"
+CONF_ACCUMULATED_GAS_USAGE  = "accumulated_gas_usage"
 
 
 
@@ -68,6 +72,14 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_WATER_FLOW): sensor.sensor_schema(
                 unit_of_measurement=UNIT_LPM,
+                accuracy_decimals=2,
+            ),
+            cv.Optional(CONF_CURRENT_GAS_USAGE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_KILOCALORIE,
+                accuracy_decimals=2,
+            ),
+            cv.Optional(CONF_ACCUMULATED_GAS_USAGE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CUBIC_METERS,
                 accuracy_decimals=2,
             ),
         }
@@ -98,6 +110,14 @@ async def to_code(config):
     if CONF_WATER_FLOW in config:
         sens = await sensor.new_sensor(config[CONF_WATER_FLOW])
         cg.add(var.set_water_flow_sensor(sens))
+
+    if CONF_CURRENT_GAS_USAGE in config:
+        sens = await sensor.new_sensor(config[CONF_CURRENT_GAS_USAGE])
+        cg.add(var.set_current_gas_sensor(sens))
+
+    if CONF_ACCUMULATED_GAS_USAGE in config:
+        sens = await sensor.new_sensor(config[CONF_ACCUMULATED_GAS_USAGE])
+        cg.add(var.set_accumulated_gas_sensor(sens))
 
 
 print ("Finished compojnents navien")

--- a/esphome/navien.yml
+++ b/esphome/navien.yml
@@ -38,6 +38,8 @@ wifi:
 
 web_server:
   port: 80
+  # Also show the internal sensors in the web server.
+  # include_internal: true
   # https://esphome.io/components/web_server.html
 
 logger:
@@ -103,26 +105,61 @@ sensor:
   - platform: navien
     name: $friendly_name Test sensor
     uart_id: main_hw_uart
+    # These are internal sensors, updated in real-time as the packets come in.
     target_temperature:
-      name: $friendly_name Target Temp
+      name: $friendly_name Target Temp (Internal)
+      id: internal_target_temp
+      internal: true
       filters:
         - lambda: return x * (9.0/5.0) + 32.0;
       unit_of_measurement: "°F"
     inlet_temperature:
-      name: $friendly_name Inlet Temp
+      name: $friendly_name Inlet Temp (Internal)
+      id: internal_inlet_temp
+      internal: true
       filters:
         - lambda: return x * (9.0/5.0) + 32.0;
       unit_of_measurement: "°F"
     outlet_temperature:
-      name: $friendly_name Outlet Temp
+      name: $friendly_name Outlet Temp (Internal)
+      id: internal_outlet_temp
+      internal: true
       filters:
         - lambda: return x * (9.0/5.0) + 32.0;
       unit_of_measurement: "°F"
     water_flow:
-      name: $friendly_name Water Flow
+      name: $friendly_name Water Flow (Internal)
+      id: internal_water_flow
+      internal: true
       filters:
         - lambda: return x / 3.785;
       unit_of_measurement: "GPM"
+
+  # These are external sensors sent to Home Assistant, updated periodically.
+  - platform: template
+    name: $friendly_name Target Temp
+    lambda: return id(internal_target_temp).state;
+    unit_of_measurement: "°F"
+    accuracy_decimals: 2
+    update_interval: 5s
+  - platform: template
+    name: $friendly_name Inlet Temp
+    lambda: return id(internal_inlet_temp).state;
+    unit_of_measurement: "°F"
+    accuracy_decimals: 2
+    update_interval: 5s
+  - platform: template
+    name: $friendly_name Outlet Temp
+    lambda: return id(internal_outlet_temp).state;
+    unit_of_measurement: "°F"
+    accuracy_decimals: 2
+    update_interval: 5s
+  - platform: template
+    name: $friendly_name Water Flow
+    lambda: return id(internal_water_flow).state;
+    unit_of_measurement: "GPM"
+    accuracy_decimals: 2
+    update_interval: 5s
       
 
 

--- a/esphome/navien.yml
+++ b/esphome/navien.yml
@@ -49,6 +49,17 @@ api:
 ota:
 
 
+output:
+  # Set the rs485 into receive mode
+  - platform: gpio
+    pin: GPIO14
+    inverted: true
+    id: uart_rs485_receive_mode
+  # Set the driver into regular mode (from undefined startup)
+  - platform: gpio
+    pin: GPIO12
+    id: uart_driver_regular_mode
+
 uart:
 #  tx_pin: TX
 #  rx_pin: RX

--- a/esphome/navien.yml
+++ b/esphome/navien.yml
@@ -135,19 +135,23 @@ sensor:
         - lambda: return x / 3.785;
       unit_of_measurement: "GPM"
     current_gas_usage:
-      name: $friendly_name Current Gas Usage
+      name: $friendly_name Current Gas Usage (Internal)
+      id: internal_current_gas_usage
+      internal: true
       # Convert from thermochemical (assumed) kcal to International Table
       # (assumed) BTU.
       filters:
-        - lambda: return x * 3.9656668314;
+        - multiply: 3.9656668314
       unit_of_measurement: "BTU"
     accumulated_gas_usage:
-      name: $friendly_name Accumulated Gas Usage
+      name: $friendly_name Accumulated Gas Usage (Internal)
+      id: internal_accumulated_gas_usage
+      internal: true
       # Convert from cubic meters to cubic feet.  This doesn't convert to therms
       # since that depends on the heating values/therm factors, which vary based
       # on the source of the gas.
       filters:
-        - lambda: return x * 35.31466672;
+        - multiply: 35.31466672
       unit_of_measurement: "ft³"
 
   # These are external sensors sent to Home Assistant, updated periodically.
@@ -173,6 +177,18 @@ sensor:
     name: $friendly_name Water Flow
     lambda: return id(internal_water_flow).state;
     unit_of_measurement: "GPM"
+    accuracy_decimals: 2
+    update_interval: 5s
+  - platform: template
+    name: $friendly_name Current Gas Usage
+    lambda: return id(internal_current_gas_usage).state;
+    unit_of_measurement: "BTU"
+    accuracy_decimals: 2
+    update_interval: 5s
+  - platform: template
+    name: $friendly_name Accumulated Gas Usage
+    lambda: return id(internal_accumulated_gas_usage).state;
+    unit_of_measurement: "ft³"
     accuracy_decimals: 2
     update_interval: 5s
       

--- a/esphome/navien.yml
+++ b/esphome/navien.yml
@@ -134,6 +134,21 @@ sensor:
       filters:
         - lambda: return x / 3.785;
       unit_of_measurement: "GPM"
+    current_gas_usage:
+      name: $friendly_name Current Gas Usage
+      # Convert from thermochemical (assumed) kcal to International Table
+      # (assumed) BTU.
+      filters:
+        - lambda: return x * 3.9656668314;
+      unit_of_measurement: "BTU"
+    accumulated_gas_usage:
+      name: $friendly_name Accumulated Gas Usage
+      # Convert from cubic meters to cubic feet.  This doesn't convert to therms
+      # since that depends on the heating values/therm factors, which vary based
+      # on the source of the gas.
+      filters:
+        - lambda: return x * 35.31466672;
+      unit_of_measurement: "ft³"
 
   # These are external sensors sent to Home Assistant, updated periodically.
   - platform: template


### PR DESCRIPTION
I wanted to see gas usage too.  See also issue #4.

I believe the units are correct, "kcal" and "m^3", based on the values I saw and what I read about the sensors.  Note that I think I saw the accumulated gas usage go down once (and not to zero), rather than always increasing, but I could be wrong.  It would be nice if that could be figured out for sure because Home Assistant cares.

I also explicitly initialized the sensors in the C++ code since code checks if they're null.  Maybe ESPHome guarantees that component objects will be zeroed out?  ...but it seemed prudent to initialize them nonetheless.

This is a child of pull request #6 (and therefore #5 too), so this contains those changes too.  GitHub doesn't have a way to represent this relationship across repositories. :(  To see only what this PR would change, you can look at mhkrebs/navien#2.
