### PR TITLE
Get 'upstream/refactor_separate_proto' compiling for me.

### DIFF
--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -22,8 +22,8 @@ void Navien::setup() {
   //digitalWrite(D6, HIGH);
 
 
-  pinMode(D2, OUTPUT);
-  digitalWrite(D2, HIGH);
+  // pinMode(D2, OUTPUT);
+  // digitalWrite(D2, HIGH);
 
   this->state.power = POWER_OFF;
 }
@@ -99,6 +99,7 @@ void Navien::update() {
   if (this->water_flow_sensor != nullptr)
     this->water_flow_sensor->publish_state(this->state.water.flow_lpm);
 
+#ifdef USE_SWITCH
   if (this->power_switch != nullptr){
     switch(this->state.power){
     case POWER_ON:
@@ -108,6 +109,7 @@ void Navien::update() {
       this->power_switch->publish_state(false);
     }
   }
+#endif
 }
 
   
@@ -134,6 +136,7 @@ void Navien::print_buffer(const uint8_t *data, size_t length) {
  }
 
 
+#ifdef USE_SWITCH
 void NavienOnOffSwitch::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Switch '%s'...", this->name_.c_str());
 
@@ -167,8 +170,10 @@ void NavienOnOffSwitch::set_parent(Navien * parent) {
 void NavienOnOffSwitch::dump_config(){
     ESP_LOGCONFIG(TAG, "Empty custom switch");
 }
+#endif
 
 
+#ifdef USE_BUTTON
 void NavienHotButton::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Button '%s'...", this->name_.c_str());
 }
@@ -185,6 +190,7 @@ void NavienHotButton::set_parent(Navien * parent) {
 void NavienHotButton::dump_config(){
     ESP_LOGCONFIG(TAG, "Navien Hot Button");
 }
+#endif
   
 }  // namespace navien
 }  // namespace esphome

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -5,10 +5,18 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
+#ifdef USE_SWITCH
 #include "esphome/components/switch/switch.h"
+#endif
 #include "esphome/components/uart/uart.h"
 
 #include "navien_link.h"
+
+#ifndef USE_SWITCH
+namespace switch_ {
+class Switch;
+}
+#endif
 
 namespace esphome {
 namespace navien {
@@ -133,6 +141,7 @@ public:
   virtual void on_error();
 };
 
+#ifdef USE_SWITCH
 class NavienOnOffSwitch : public switch_::Switch, public Component {
     protected:
       Navien * parent;
@@ -143,7 +152,9 @@ class NavienOnOffSwitch : public switch_::Switch, public Component {
       void write_state(bool state) override;
       void dump_config() override;
 };
+#endif
 
+#ifdef USE_BUTTON
 class NavienHotButton : public button::Button, public Component {
     protected:
       Navien * parent;
@@ -155,6 +166,7 @@ class NavienHotButton : public button::Button, public Component {
       void press_action() override;
       void dump_config() override;
 };
+#endif
     
 }  // namespace navien
 }  // namespace esphome

--- a/esphome/components/navien/navien_link.cpp
+++ b/esphome/components/navien/navien_link.cpp
@@ -223,7 +223,7 @@ void NavienLink::receive() {
   }
 }
 
-void NavienLink::send_cmd(const uint8_t * buffer, uint8 len){
+void NavienLink::send_cmd(const uint8_t * buffer, uint8_t len){
   /*  if (buffer && len){
     this->write_array(buffer, len);
     }*/

--- a/esphome/components/navien/navien_link.h
+++ b/esphome/components/navien/navien_link.h
@@ -5,7 +5,9 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
+#ifdef USE_SWITCH
 #include "esphome/components/switch/switch.h"
+#endif
 #include "esphome/components/uart/uart.h"
 
 #include "navien_proto.h"
@@ -147,7 +149,7 @@ protected:
 
 
 protected:
-  void send_cmd(const uint8_t * buffer, uint8 len);
+  void send_cmd(const uint8_t * buffer, uint8_t len);
   
 protected:
   // Uart Send/Receive facility

--- a/esphome/components/navien/navien_proto.h
+++ b/esphome/components/navien/navien_proto.h
@@ -11,7 +11,9 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
+#ifdef USE_SWITCH
 #include "esphome/components/switch/switch.h"
+#endif
 #include "esphome/components/uart/uart.h"
 
 namespace esphome {

--- a/esphome/navien.yml
+++ b/esphome/navien.yml
@@ -50,6 +50,11 @@ api:
 ota:
 
 
+output:
+  - platform: gpio
+    pin: GPIO4  # D2 on esp8266
+    id: uart_esp8266_d2
+
 uart:
   tx_pin: GPIO15
   rx_pin:


### PR DESCRIPTION
Put the switch/button code under `USE_SWITCH`/`USE_BUTTON` in case the YAML config doesn't have a "switch:"/"button:" section.  Move the pin write into the YAML config because my board doesn't have that pin.

I mentioned it in PR #5 also, but I kept the `#ifdef` conditionals in there since the sensors are already conditional.  But I'm not married to that if you want to require "switch:" and "button:".
