### PR TITLE
Fix uninitialized bugs.

### DIFF
--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -85,14 +85,14 @@ protected:
   /**
    * Sensor definitions
    */
-  sensor::Sensor *target_temp_sensor;
-  sensor::Sensor *outlet_temp_sensor;
-  sensor::Sensor *inlet_temp_sensor;
-  sensor::Sensor *water_flow_sensor;
-  sensor::Sensor *gas_total_sensor;
-  sensor::Sensor *gas_current_sensor;
+  sensor::Sensor *target_temp_sensor = nullptr;
+  sensor::Sensor *outlet_temp_sensor = nullptr;
+  sensor::Sensor *inlet_temp_sensor = nullptr;
+  sensor::Sensor *water_flow_sensor = nullptr;
+  sensor::Sensor *gas_total_sensor = nullptr;
+  sensor::Sensor *gas_current_sensor = nullptr;
 
-  switch_::Switch *power_switch;
+  switch_::Switch *power_switch = nullptr;
   bool is_rt;
 };
 		   
@@ -119,7 +119,7 @@ protected:
 protected:
   // Data, extracted from gas and water packers and stored
   // Once the "update" is called this data gets reported to readers.
-  NAVIEN_STATE state;
+  NAVIEN_STATE state = {};
 
 protected:
   /**
@@ -147,7 +147,7 @@ public:
 #ifdef USE_SWITCH
 class NavienOnOffSwitch : public switch_::Switch, public Component {
     protected:
-      Navien * parent;
+      Navien * parent = nullptr;
     public:
       void setup() override;
 
@@ -160,7 +160,7 @@ class NavienOnOffSwitch : public switch_::Switch, public Component {
 #ifdef USE_BUTTON
 class NavienHotButton : public button::Button, public Component {
     protected:
-      Navien * parent;
+      Navien * parent = nullptr;
     public:
       void setup() override;
 

--- a/esphome/components/navien/navien_link.h
+++ b/esphome/components/navien/navien_link.h
@@ -163,7 +163,7 @@ protected:
 
   // Keeps track of the state machine and iterates through
   // initialized -> marker found -> header parsed -> data parsed -> initialized
-  READ_STATE   recv_state;
+  READ_STATE   recv_state = INITIAL;
 
   // Data received off the wire
   RECV_BUFFER  recv_buffer;


### PR DESCRIPTION
My esphome firmware started hanging because `recv_state` was set to something random.

This would have been an issue before, but somehow with the simpler architecture it was likely zeroed memory by happenchance.
