### PR TITLE
ESPHome Device Builder configs and other tweaks

### DIFF
--- a/esphome/components/navien/button.py
+++ b/esphome/components/navien/button.py
@@ -1,0 +1,29 @@
+from esphome.components import button
+import esphome.config_validation as cv
+import esphome.codegen as cg
+from esphome.const import CONF_ID, CONF_ICON
+from esphome.components.navien.sensor import NAVIEN_CONFIG_ID, Navien
+
+navien_ns = cg.esphome_ns.namespace("navien")
+NavienHotButton = navien_ns.class_("NavienHotButton", button.Button, cg.Component)
+
+AUTO_LOAD = ["sensor"]
+CONFIG_SCHEMA = (
+    button.button_schema(NavienHotButton)
+    .extend(
+        {
+            cv.GenerateID(NAVIEN_CONFIG_ID): cv.use_id(Navien),
+            cv.Optional(CONF_ICON, default="mdi:fire-circle"): cv.icon,
+        }
+    )
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+async def to_code(config):
+    var = await button.new_button(config)
+    await cg.register_component(var, config)
+    if CONF_ICON in config:
+        cg.add(var.set_icon(config[CONF_ICON]))
+
+    hub = await cg.get_variable(config[NAVIEN_CONFIG_ID])
+    cg.add(var.set_parent(hub))

--- a/esphome/components/navien/navien_link.cpp
+++ b/esphome/components/navien/navien_link.cpp
@@ -174,7 +174,7 @@ void NavienLink::send_hot_button_cmd(){
   //return;  
     this->send_cmd(HOT_BUTTON_PRESS_CMD, sizeof(HOT_BUTTON_PRESS_CMD));
     //    delay(1);
-    this->send_cmd(HOT_BUTTON_PRESS_CMD, sizeof(HOT_BUTTON_PRESS_CMD));
+    // this->send_cmd(HOT_BUTTON_PRESS_CMD, sizeof(HOT_BUTTON_PRESS_CMD));
     //delay(15);
     this->send_cmd(HOT_BUTTON_RELSE_CMD, sizeof(HOT_BUTTON_RELSE_CMD));
 }

--- a/esphome/components/navien/sensor.py
+++ b/esphome/components/navien/sensor.py
@@ -21,6 +21,7 @@ Navien = navien_ns.class_("Navien", cg.PollingComponent, uart.UARTDevice)
 
 from esphome.const import (
     CONF_ID, UNIT_EMPTY, ICON_EMPTY,
+    CONF_ICON,
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_SENSOR,
@@ -116,30 +117,37 @@ async def to_code(config):
 
     if CONF_TARGET_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_TARGET_TEMPERATURE])
+        cg.add(sens.set_icon(config[CONF_TARGET_TEMPERATURE].get(CONF_ICON, "mdi:coolant-temperature")))
         cg.add(var.set_target_temp_sensor(sens))
         
     if CONF_INLET_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_INLET_TEMPERATURE])
+        cg.add(sens.set_icon(config[CONF_INLET_TEMPERATURE].get(CONF_ICON, "mdi:water-thermometer")))
         cg.add(var.set_inlet_temp_sensor(sens))
         
     if CONF_OUTLET_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_OUTLET_TEMPERATURE])
+        cg.add(sens.set_icon(config[CONF_OUTLET_TEMPERATURE].get(CONF_ICON, "mdi:water-thermometer-outline")))
         cg.add(var.set_outlet_temp_sensor(sens))
 
     if CONF_WATER_FLOW in config:
         sens = await sensor.new_sensor(config[CONF_WATER_FLOW])
+        cg.add(sens.set_icon(config[CONF_WATER_FLOW].get(CONF_ICON, "mdi:gauge")))
         cg.add(var.set_water_flow_sensor(sens))
 
     if CONF_WATER_UTILIZATION in config:
         sens = await sensor.new_sensor(config[CONF_WATER_UTILIZATION])
+        cg.add(sens.set_icon(config[CONF_WATER_UTILIZATION].get(CONF_ICON, "mdi:water-percent")))
         cg.add(var.set_water_utilization_sensor(sens))
         
     if CONF_GAS_TOTAL in config:
         sens = await sensor.new_sensor(config[CONF_GAS_TOTAL])
+        cg.add(sens.set_icon(config[CONF_GAS_TOTAL].get(CONF_ICON, "mdi:meter-gas")))
         cg.add(var.set_gas_total_sensor(sens))
 
     if CONF_GAS_CURRENT in config:
         sens = await sensor.new_sensor(config[CONF_GAS_CURRENT])
+        cg.add(sens.set_icon(config[CONF_GAS_CURRENT].get(CONF_ICON, "mdi:gas-burner")))
         cg.add(var.set_gas_current_sensor(sens))
         
     if CONF_REAL_TIME in config:

--- a/esphome/components/navien/sensor.py
+++ b/esphome/components/navien/sensor.py
@@ -29,7 +29,10 @@ from esphome.const import (
     CONF_TARGET_TEMPERATURE,
 
     DEVICE_CLASS_CONNECTIVITY,
-    
+    DEVICE_CLASS_GAS,
+
+    STATE_CLASS_TOTAL_INCREASING,
+
     UNIT_CUBIC_METER,
     UNIT_DEGREES,
     UNIT_CELSIUS,
@@ -92,6 +95,8 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_GAS_TOTAL): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CUBIC_METER,
                 accuracy_decimals=2,
+                device_class=DEVICE_CLASS_GAS,
+                state_class=STATE_CLASS_TOTAL_INCREASING,
             ),
             cv.Optional(CONF_GAS_CURRENT): sensor.sensor_schema(
                 unit_of_measurement=UNIT_BTU,
@@ -142,7 +147,6 @@ async def to_code(config):
         
     if CONF_GAS_TOTAL in config:
         sens = await sensor.new_sensor(config[CONF_GAS_TOTAL])
-        cg.add(sens.set_icon(config[CONF_GAS_TOTAL].get(CONF_ICON, "mdi:meter-gas")))
         cg.add(var.set_gas_total_sensor(sens))
 
     if CONF_GAS_CURRENT in config:

--- a/esphome/navien-esphome-atom-lite-esp32.yml
+++ b/esphome/navien-esphome-atom-lite-esp32.yml
@@ -1,0 +1,43 @@
+substitutions:
+  tx_pin: 19
+  rx_pin: 22
+
+esphome:
+  name: ${name}
+  friendly_name: Navien
+  comment: Navien ATOM Lite ESP32
+  name_add_mac_suffix: true
+  platformio_options:
+    board_build.flash_mode: dio
+  project:
+    name: "Navien.ATOM-Lite-ESP32"
+    version: "${version}"
+
+esp32:
+  board: m5stack-atom
+  framework:
+    type: arduino
+
+dashboard_import:
+  package_import_url: github://htumanyan/navien/esphome/navien-esphome-atom-lite-esp32.yml
+  import_full_config: false
+
+ota:
+  - platform: esphome
+    id: ota_default
+
+wifi:
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: "Navien ATOM Lite ESP32 Hotspot"
+
+light:
+  - platform: fastled_clockless
+    chipset: SK6812
+    pin: 27
+    num_leds: 1
+    rgb_order: GRB
+    name: "FastLED Light"
+
+packages:
+  core: !include navien-esphome-base.yml

--- a/esphome/navien-esphome-base.yml
+++ b/esphome/navien-esphome-base.yml
@@ -86,10 +86,6 @@ sensor:
       unit_of_measurement: "%"
     gas_total:
       name: Accumulated Gas Usage
-      filters:
-        - lambda: return x * 9131.0 / 25193.0 / 10.0;
-      unit_of_measurement: "Therms"
-      accuracy_decimals: 1
     gas_current:
       name: Current Gas Usage
       filters:

--- a/esphome/navien-esphome-base.yml
+++ b/esphome/navien-esphome-base.yml
@@ -42,7 +42,7 @@ button:
   - platform: restart
     name: "Restart"
   - platform: navien
-    name: NavienHotButton
+    name: Hot Button
 
 climate:
   - platform: navien

--- a/esphome/navien-esphome-base.yml
+++ b/esphome/navien-esphome-base.yml
@@ -1,0 +1,120 @@
+substitutions:
+  name: navien-heater
+  device_description: "Navien Gas Water Heater"
+  version:  "0.0.0.1"
+
+logger:
+  level: INFO
+  baud_rate: 0 #disable logging over uart
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/htumanyan/navien
+      path: esphome/components
+    refresh: 1h
+    components: [navien]
+
+captive_portal:
+
+web_server:
+  port: 80
+  version: 3
+
+api:
+
+uart:
+  tx_pin: ${tx_pin}
+  rx_pin:
+    number: ${rx_pin}
+    mode:
+      input: true
+      pullup: false
+  baud_rate: 19200
+  stop_bits: 1
+  parity: none
+  rx_buffer_size: 8192
+  id: main_hw_uart
+
+binary_sensor:
+
+button:
+  - platform: restart
+    name: "Restart"
+  - platform: navien
+    name: NavienHotButton
+
+climate:
+  - platform: navien
+    id: navien_climate
+    name: Target Temperature
+    visual:
+      min_temperature: 97F
+      max_temperature: 120.5F
+      temperature_step: '0.5'
+
+sensor:
+  - platform: uptime
+    name: Uptime Sensor
+  - platform: wifi_signal
+    name: WiFi Signal
+  - platform: navien
+    name: Metrics
+    uart_id: main_hw_uart
+    target_temperature:
+      name: Target Temp
+      filters:
+        - lambda: return x * (9.0/5.0) + 32.0;
+      unit_of_measurement: "°F"
+    inlet_temperature:
+      name: Inlet Temp
+      filters:
+        - lambda: return x * (9.0/5.0) + 32.0;
+      unit_of_measurement: "°F"
+    outlet_temperature:
+      name: Outlet Temp
+      filters:
+        - lambda: return x * (9.0/5.0) + 32.0;
+      unit_of_measurement: "°F"
+    water_flow:
+      name: Water Flow
+      filters:
+        - lambda: return x / 3.785;
+      unit_of_measurement: "GPM"
+    water_utilization:
+      name: Water Capacity Utilization
+      unit_of_measurement: "%"
+    gas_total:
+      name: Accumulated Gas Usage
+      filters:
+        - lambda: return x * 9131.0 / 25193.0 / 10.0;
+      unit_of_measurement: "Therms"
+      accuracy_decimals: 1
+    gas_current:
+      name: Current Gas Usage
+      filters:
+        - lambda: return x * 3.9680;
+      unit_of_measurement: "BTU"
+      accuracy_decimals: 1
+    conn_status:
+      name: Connection Status
+    recirc_status:
+      name: Recirculation Status
+    # real_time: true
+
+switch:
+  - platform: navien
+    name: Power On/Off
+
+text_sensor:
+  - platform: version
+    name: ESPHome Version
+    id: esphome_version
+    hide_timestamp: True
+  - platform: wifi_info
+    ip_address:
+      id: ip_address
+      name: IP Address
+    mac_address:
+      name: Mac
+      id: mac_address

--- a/esphome/navien-esphome-device-example.yml
+++ b/esphome/navien-esphome-device-example.yml
@@ -1,0 +1,30 @@
+substitutions:
+  name: navien-heater
+  friendly_name: Navien
+
+esphome:
+  name: ${name}
+  friendly_name: ${friendly_name}
+  name_add_mac_suffix: false
+
+wifi:
+  ssid: !secret esp_wifi_ssid
+  password: !secret esp_wifi_password
+  domain: !secret esp_wifi_domain
+
+packages:
+  Navien.ATOM-Lite-ESP32: github://htumanyan/navien/esphome/navien-esphome-atom-lite-esp32.yml
+
+api:
+  encryption:
+    key: !secret esp_api_key
+
+ota:
+  - password: !secret esp_ota_password
+    platform: esphome
+
+web_server:
+  ota: false
+  auth:
+    username: !secret esp_web_user
+    password: !secret esp_web_password


### PR DESCRIPTION
PR offers up the following...

- Python code generation for the hot button
- Comments double-send of hot button press, doesn't seem to need it in my testing but could be reverted
- Adds default icons to sensor objects that don't have a default device_class
- Adds config YAML files that work with the ESPHome Device Builder add-on
  - `esphome/navien-esphome-base.yml` - Includes all objects and configurations that _should_ be common across any hardware type
  - `esphome/navien-esphome-atom-lite-esp32.yml` - A "package" file that covers the ATOM Lite ESP32 that's used with the RS485 base. Could be copied and adapted for other hardware types
  - `esphome/navien-esphome-device-example.yml` - A sample config that an end user can use in the device builder UI