### PR TITLE
Fix climate traits API for ESPHome 2025.11.4 compatibility

### DIFF
--- a/esphome/components/navien/climate/navien_climate.cpp
+++ b/esphome/components/navien/climate/navien_climate.cpp
@@ -8,26 +8,24 @@ namespace navien {
   
 static const char *TAG = "navien.climate";
 
-static const std::set<climate::ClimateMode> supported_modes = {climate::CLIMATE_MODE_OFF, climate::CLIMATE_MODE_HEAT};
-  
 void NavienClimate::setup(){
 }
   
 void NavienClimate::dump_config(){
 }
 
-
 climate::ClimateTraits NavienClimate::traits(){
-    auto traits = climate::ClimateTraits();
-    
-    traits.set_supports_current_temperature(true);
-    traits.set_supported_modes(supported_modes);
-    return traits;
+  climate::ClimateTraits traits;
+
+  traits.set_supports_current_temperature(true);
+  traits.add_supported_mode(climate::CLIMATE_MODE_OFF);
+  traits.add_supported_mode(climate::CLIMATE_MODE_HEAT);
+
+  return traits;
 }
   
 void NavienClimate::control(const climate::ClimateCall &call){
   if (call.get_target_temperature().has_value()){
-      
     esphome::optional<float> f = call.get_target_temperature();
     float target = *f;
     
@@ -35,7 +33,6 @@ void NavienClimate::control(const climate::ClimateCall &call){
     parent->send_set_temp_cmd(target);
   }
     
-  //    std::string mode_id;
   if (call.get_mode().has_value()) {
     climate::ClimateMode mode = call.get_mode().value();
     ESP_LOGD(TAG, "Setting mode to %s", climate::climate_mode_to_string(mode));


### PR DESCRIPTION
ClimateTraits::set_supported_modes() no longer accepts std::set<ClimateMode>. ESPHome has migrated to a bitmask-based system for climate modes. Without this change, using the latest esphome, I get:

~~~
error: cannot convert 'const std::set<esphome::climate::ClimateMode>' 
to 'esphome::climate::ClimateModeMask'
...
void set_supported_modes(ClimateModeMask modes)
~~~