### PR TITLE
Add support for scheduled recirculation (not hot button) mode

### DIFF
--- a/esphome/components/navien/navien_link.h
+++ b/esphome/components/navien/navien_link.h
@@ -107,11 +107,18 @@ public:
   */
   
   /**
+   * Returns true if we're sharing the RS485 bus with another NaviLink-like device, otherwise false.
+   */
+  bool is_other_navilink_installed(){return this->other_navilink_installed;}
+  
+  /**
    * Send commands
    */
   void send_turn_on_cmd();
   void send_turn_off_cmd();
   void send_hot_button_cmd();
+  void send_scheduled_recirculation_on_cmd();
+  void send_scheduled_recirculation_off_cmd();
   void send_set_temp_cmd(float temp);
 
   
@@ -161,8 +168,9 @@ protected:
    *
    * @param buffer - command to be sent.
    * @param len - the length of buffer
+   * @param tries - number of times to send the command
    */
-  void send_cmd(const uint8_t * buffer, uint8_t len);
+  void send_cmd(const uint8_t * buffer, uint8_t len, uint8_t tries = 2);
   
 protected:
   // Uart Send/Receive facility
@@ -178,6 +186,9 @@ protected:
 
   // Data received off the wire
   RECV_BUFFER  recv_buffer;
+
+  // Flag indicating if we've seen control packets that we didn't send, which means an actual NaviLink is also present
+  bool other_navilink_installed = false;
 
   // Buffer for queued commands.
   // TODO: add thread safety - cmd_buffer is used in different thread contexts

--- a/esphome/components/navien/navien_link_esp.h
+++ b/esphome/components/navien/navien_link_esp.h
@@ -43,6 +43,9 @@ public:
   void send_turn_off_cmd() { this->navien_link.send_turn_off_cmd(); }
   void send_hot_button_cmd() { this->navien_link.send_hot_button_cmd(); }
   void send_set_temp_cmd(float temp) { this->navien_link.send_set_temp_cmd(temp); }
+  void send_scheduled_recirculation_on_cmd() { this->navien_link.send_scheduled_recirculation_on_cmd(); }
+  void send_scheduled_recirculation_off_cmd() { this->navien_link.send_scheduled_recirculation_off_cmd(); }
+  bool is_other_navilink_installed() { return this->navien_link.is_other_navilink_installed(); }
 
   /**
    * Component interface - called in the main loop

--- a/esphome/components/navien/sensor.py
+++ b/esphome/components/navien/sensor.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import sensor, binary_sensor, uart
+from esphome.components import sensor, binary_sensor, text_sensor, uart
 from esphome.components import output
 from esphome.core import ID  
 
@@ -24,6 +24,9 @@ from esphome.const import (
     
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_GAS,
+    DEVICE_CLASS_RUNNING,
+    
+    ENTITY_CATEGORY_DIAGNOSTIC,
     
     STATE_CLASS_TOTAL_INCREASING,
     
@@ -46,10 +49,13 @@ CONF_GAS_TOTAL          = "gas_total"
 CONF_GAS_CURRENT        = "gas_current"
 CONF_SH_OUTLET_TEMPERATURE = "sh_outlet_temperature"
 CONF_SH_RETURN_TEMPERATURE = "sh_return_temperature"
+CONF_SCHEDULED_RECIRC_RUNNING = "scheduled_recirc_running"
+CONF_HOTBUTTON_RECIRC_RUNNING = "hotbutton_recirc_running"
+
 CONF_CONN_STATUS        = "conn_status"
 CONF_REAL_TIME          = "real_time"
 CONF_HEAT_CAPACITY      = "heat_capacity"
-CONF_RECIRC_STATUS      = "recirc_status"
+CONF_RECIRC_MODE        = "recirc_mode"
 CONF_TOTAL_DHW_USAGE    = "total_dhw_usage"
 CONF_TOTAL_OPERATING_TIME       = "total_operating_time"
 CONF_BOILER_ACTIVE              = "boiler_active"
@@ -57,6 +63,7 @@ CONF_CUMULATIVE_DWH_USAGE_HOURS = "total_dhw_usage_hours"
 CONF_CUMULATIVE_SH_USAGE_HOURS  = "total_sh_usage_hours"
 CONF_DAYS_SINCE_INSTALL         = "days_since_install"
 CONF_SRC                        = "src"
+CONF_OTHER_NAVILINK_INSTALLED   = "other_navilink_installed"
 
 
 CONFIG_SCHEMA = cv.All(
@@ -86,6 +93,12 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_WATER_UTILIZATION): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=2,
+            ),
+            cv.Optional(CONF_SCHEDULED_RECIRC_RUNNING): binary_sensor.binary_sensor_schema(
+                device_class = DEVICE_CLASS_RUNNING
+            ),
+            cv.Optional(CONF_HOTBUTTON_RECIRC_RUNNING): binary_sensor.binary_sensor_schema(
+                device_class = DEVICE_CLASS_RUNNING
             ),
             cv.Optional(CONF_GAS_TOTAL): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CUBIC_METER,
@@ -134,7 +147,11 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_CONN_STATUS): binary_sensor.binary_sensor_schema(
                 device_class = DEVICE_CLASS_CONNECTIVITY
             ),
-            cv.Optional(CONF_RECIRC_STATUS): binary_sensor.binary_sensor_schema(),
+            cv.Optional(CONF_RECIRC_MODE): text_sensor.text_sensor_schema(),
+            cv.Optional(CONF_OTHER_NAVILINK_INSTALLED): binary_sensor.binary_sensor_schema(
+                device_class = DEVICE_CLASS_CONNECTIVITY,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+            ),
             cv.Optional(CONF_REAL_TIME): cv.boolean,
             cv.Optional(CONF_SRC): cv.int_range(min=0, max=15)
         }
@@ -199,6 +216,16 @@ async def to_code(config):
         sens = await sensor.new_sensor(config[CONF_WATER_UTILIZATION])
         cg.add(sens.set_icon(config[CONF_WATER_UTILIZATION].get(CONF_ICON, "mdi:water-percent")))
         cg.add(var.set_water_utilization_sensor(sens))
+
+    if CONF_SCHEDULED_RECIRC_RUNNING in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_SCHEDULED_RECIRC_RUNNING])
+        cg.add(sens.set_icon(config[CONF_SCHEDULED_RECIRC_RUNNING].get(CONF_ICON, "mdi:water-sync")))
+        cg.add(var.set_scheduled_recirc_running_sensor(sens))
+
+    if CONF_HOTBUTTON_RECIRC_RUNNING in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_HOTBUTTON_RECIRC_RUNNING])
+        cg.add(sens.set_icon(config[CONF_HOTBUTTON_RECIRC_RUNNING].get(CONF_ICON, "mdi:water-sync")))
+        cg.add(var.set_hotbutton_recirc_running_sensor(sens))
         
     if CONF_GAS_TOTAL in config:
         sens = await sensor.new_sensor(config[CONF_GAS_TOTAL])
@@ -216,9 +243,9 @@ async def to_code(config):
         sens = await binary_sensor.new_binary_sensor(config[CONF_CONN_STATUS])
         cg.add(var.set_conn_status_sensor(sens))
         
-    if CONF_RECIRC_STATUS in config:
-        sens = await binary_sensor.new_binary_sensor(config[CONF_RECIRC_STATUS])
-        cg.add(var.set_recirc_status_sensor(sens))
+    if CONF_RECIRC_MODE in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_RECIRC_MODE])
+        cg.add(var.set_recirc_mode_sensor(sens))
     
     if CONF_BOILER_ACTIVE in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_BOILER_ACTIVE])
@@ -264,3 +291,6 @@ async def to_code(config):
         cg.add(sens.set_icon(config[CONF_DAYS_SINCE_INSTALL].get(CONF_ICON, "mdi:calendar-clock")))
         cg.add(var.set_days_since_install_sensor(sens))
  
+    if CONF_OTHER_NAVILINK_INSTALLED in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_OTHER_NAVILINK_INSTALLED])
+        cg.add(var.set_other_navilink_installed_sensor(sens))

--- a/esphome/components/navien/switch.py
+++ b/esphome/components/navien/switch.py
@@ -1,6 +1,7 @@
 from esphome.components import switch
 import esphome.config_validation as cv
 import esphome.codegen as cg
+from esphome.const import CONF_ICON, CONF_TYPE
 
 from esphome.components.navien.sensor import NAVIEN_CONFIG_ID, Navien
 
@@ -9,21 +10,41 @@ AUTO_LOAD = ["switch", "sensor"]
 navien_ns = cg.esphome_ns.namespace("navien")
 
 NavienOnOff = navien_ns.class_("NavienOnOffSwitch", switch.Switch, cg.Component)
+NavienAllowScheduledRecircSwitch = navien_ns.class_("NavienAllowScheduledRecircSwitch", switch.Switch, cg.Component)
 
-CONFIG_SCHEMA = (
-    switch.switch_schema(NavienOnOff)
-    .extend(
-        {
-            cv.GenerateID(NAVIEN_CONFIG_ID): cv.use_id(Navien),
-        }
-    )
-    .extend(cv.COMPONENT_SCHEMA)
+TYPE_POWER = "power"
+TYPE_ALLOW_SCHEDULED_RECIRC = "allow_scheduled_recirc"
+
+
+CONFIG_SCHEMA = cv.typed_schema(
+    {
+        TYPE_POWER: switch.switch_schema(NavienOnOff)
+        .extend(
+            {
+                cv.GenerateID(NAVIEN_CONFIG_ID): cv.use_id(Navien),
+            }
+        )
+        .extend(cv.COMPONENT_SCHEMA),
+        TYPE_ALLOW_SCHEDULED_RECIRC: switch.switch_schema(NavienAllowScheduledRecircSwitch)
+        .extend(
+            {
+                cv.GenerateID(NAVIEN_CONFIG_ID): cv.use_id(Navien),
+                cv.Optional(CONF_ICON, default="mdi:water-sync"): cv.icon,
+            }
+        )
+        .extend(cv.COMPONENT_SCHEMA),
+    },
+    key=CONF_TYPE,
+    default_type=TYPE_POWER,
 )
 
 
 async def to_code(config):
     var = await switch.new_switch(config)
     await cg.register_component(var, config)
+
+    if CONF_ICON in config:
+        cg.add(var.set_icon(config[CONF_ICON]))
     
     paren = await cg.get_variable(config[NAVIEN_CONFIG_ID])
     cg.add(var.set_parent(paren))

--- a/esphome/navien-base.yml
+++ b/esphome/navien-base.yml
@@ -54,7 +54,15 @@ binary_sensor:
 switch:
   - platform: navien
     navien: navien_main
+    type: power
     name: ${friendly_name} Main Power On/Off
+    id: main_power
+  # "Allow Recirculation" turns on recirculation when the water heater is not in HotButton mode
+  - platform: navien
+    navien: navien_main
+    type: allow_scheduled_recirc
+    name: "${friendly_name} Allow Recirculation"
+    id: allow_scheduled_recirc
 
 
 button:

--- a/esphome/navien-sensors.yml
+++ b/esphome/navien-sensors.yml
@@ -104,9 +104,19 @@ sensor:
     conn_status:
       id: conn_status
       name: "${friendly_name} Connection Status${sensor_suffix}"
-    recirc_status:
-      id: recirc_status
-      name: "${friendly_name} Recirculation Status${sensor_suffix}"   
+    recirc_mode:
+      id: recirc_mode
+      name: "${friendly_name} Recirculation Mode${sensor_suffix}"
     boiler_active:
       id: boiler_active
       name: "${friendly_name} Boiler Active${sensor_suffix}"
+    hotbutton_recirc_running:
+      id: hotbutton_recirc_running
+      name: "${friendly_name} Hot Button Recirculation${sensor_suffix}"
+    scheduled_recirc_running:
+      id: scheduled_recirc_running
+      name: "${friendly_name} Scheduled Recirculation${sensor_suffix}"
+    # this will be true if another NaviLink device is also connected
+    other_navilink_installed:
+      id: other_navilink_installed
+      name: "${friendly_name} Other NaviLink Installed${sensor_suffix}"  

--- a/navien_schedule_automation_blueprint.yaml
+++ b/navien_schedule_automation_blueprint.yaml
@@ -1,0 +1,207 @@
+blueprint:
+  name: Navien Scheduled Recirculation 
+  description: >
+    Automates turning on Navien water heater recirculation based on a schedule and other triggers. 
+    
+    This automation only works if your Navien water heater is configured to use scheduled ("Always On", "Intelligent",
+    or "Weekly") recirculation. It will not work if the water heater is configured for "HotButton" recirculation.
+
+    Version: 1.0.1
+  domain: automation
+  input:
+    recirculation_schedule:
+      name: Navien Water Recirculation Schedule
+      description: >
+        Set this to a schedule entity to monitor for when recirculation should be active. A schedule can be created
+        using the [Schedule](https://www.home-assistant.io/integrations/schedule/) integration.
+      selector:
+        entity:
+          domain: schedule
+    navien_recirculation_switch:
+      name: Navien Allow Recirculation
+      description: >
+        Set this to the "Allow Recirculation" switch from your Navien device. This controls whether the Navien is
+        allowed to recirculate water right now.
+      selector:
+        entity:
+          filter:
+            - domain: switch
+              integration: esphome
+    navien_circulating:
+      name: Navien Scheduled Recirculation
+      description: >
+        Set this to the "Scheduled Recirculation" sensor from your Navien device. This indicates if the Navien is 
+        actively recirculating water.
+      selector:
+        entity:
+          filter:
+            - domain: binary_sensor
+              integration: esphome
+    navien_mode:
+      name: Navien Recirculation Mode
+      description: >
+        Set this to the "Recirculation Mode" sensor entity from your Navien device. This is used to ensure that your
+        Navien is properly configured for this automation; if it is not, you will get a notification of the issue when
+        the automation tries to enable recirculation.
+      selector:
+        entity:
+          filter:
+            - domain: sensor
+              integration: esphome
+    navien_hotbutton:
+      name: Navien HotButton
+      description: >
+        Set this to a button or helper toggle. If you have multiple physical buttons that you'd like to use as 
+        triggers, you can set this to a button group helper containing all of them. If your Navien device in exposes
+        a "HotButton" button entity, you can use that as well, since it doesn't do anything otherwise if your Navien
+        is set to scheduled recirculation mode.
+
+        Pressing this button will trigger an immediate water recirculation cycle, regardless of the schedule or 
+        alternate triggers.
+      selector:
+        entity:
+          filter:
+            - domain: button
+              integration: esphome
+    alternate_recirculation_switch:
+      name: Alternate Recirculation Trigger
+      description: >
+        _(Optional)_ A switch that, when turned on, will also enable recirculation. Recirculation will be enabled when
+        either this switch is "on" or the schedule is in an "on" period.
+
+        Suggestions: 
+          * Set this to a "on when any member is on" helper group to allow light switches to enable recirculation
+            when certain bathroom lights are on.
+          * Set this to an toggle helper that is controlled by another automation to enable recirculation on demand 
+            when certain conditions are met (e.g. motion detected in bathroom, washing machine is on, etc). Just make
+            sure that automation is designed to only set the toggle to "off" when none of the conditions are present.
+      selector:
+        entity:
+          domain: 
+            - switch
+            - input_boolean
+      default: ""
+trigger_variables:
+  schedule_entity: !input recirculation_schedule
+  alternate_entity: !input alternate_recirculation_switch
+variables:
+  schedule_and_alternate_are_off: >
+    {{ is_state(schedule_entity, 'off') and (alternate_entity == "" or is_state(alternate_entity, 'off')) }}
+  navien_mode: !input navien_mode
+  other_navilink_present: >
+     {{ device_entities(device_id(schedule_entity)) | select('search', 'navilink') | first | default('') }}
+triggers:
+  - trigger: state
+    id: schedule_on
+    entity_id: !input recirculation_schedule
+    to: "on"
+  - trigger: state
+    id: schedule_off
+    entity_id: !input recirculation_schedule
+    to: "off"
+  - trigger: template
+    value_template: >-
+      {{ is_state(alternate_entity, 'on') }}
+    id: alternate_on
+  - trigger: template
+    value_template: >-
+      {{ is_state(alternate_entity, 'off') }}
+    id: alternate_off
+  - trigger: state
+    id: hotbutton
+    entity_id: !input navien_hotbutton
+actions:
+  # Complain if the Navien is in the wrong mode. But keep going, because the Navien will remember the state
+  # of "Allow Recirculation" even if it's in the wrong mode, and recirculation will start if the user fixes it.
+  - if:
+      - condition: template
+        value_template: >-
+          {{ not is_state(navien_mode, 'Scheduled') }}
+    then:
+      - service: persistent_notification.create
+        data:
+          title: "Navien Scheduled Recirculation Automation Issue"
+          message: >
+            The Navien Scheduled Recirculation Automation attempted to enable recirculation, but the Navien
+            water heater is not configured for scheduled recirculation mode. Please set the water heater's
+            recirculation mode to "Always On", "Intelligent", or "Weekly" in order for this automation to work.
+          notification_id: navien_scheduled_recirculation_error
+  # Complain if another NaviLink is present, as it will likely block our attempts to control the schedule
+  - if:
+      - condition: template
+        value_template: >-
+          {{ is_state(other_navilink_present, 'on') }}
+    then:
+      - service: persistent_notification.create
+        data:
+          title: "Navien Scheduled Recirculation Automation Issue"
+          message: >
+            The Navien Scheduled Recirculation Automation attempted to enable recirculation, but another NaviLink
+            appears to be connected. True NaviLink devices will insist on controlling the recirculation schedule 
+            and will thwart any attempts by this automation to do the same. Please disconnect the other NaviLink
+            and reset your ESPHome device in order to use this automation.
+          notification_id: navien_scheduled_recirculation_error
+
+  - choose:
+      # Simulate the hot button by turning on recirculation and letting it run a complete cycle.
+      - conditions:
+          - condition: trigger
+            id: hotbutton
+        sequence:
+          # If scheduled recirculation is enabled, disable it first. Disabling and re-enabling it will trigger a 
+          # recirculation cycle.
+          - if:
+              - condition: state
+                entity_id: !input navien_recirculation_switch
+                state: "on"
+            then:
+              - action: switch.turn_off
+                target:
+                  entity_id: !input navien_recirculation_switch
+              - delay:
+                  hours: 0
+                  minutes: 0
+                  seconds: 5
+                  milliseconds: 0
+          # Enable recirculation. The water heater will immediately start a recirculation cycle.
+          - action: switch.turn_on
+            target:
+              entity_id: !input navien_recirculation_switch
+            data: {}
+          # Wait for the recirculation cycle to finish.
+          - wait_for_trigger:
+              - trigger: state
+                entity_id: !input navien_circulating
+                from: "on"
+                to: "off"
+          # Stop here if recirculation is supposed to be on right now, leaving it on.
+          - condition: template
+            value_template: "{{ schedule_and_alternate_are_off }}"
+          - action: switch.turn_off
+            target:
+              entity_id: !input navien_recirculation_switch
+      # Enable recirculation when either the schedule or alternate trigger turns on.
+      - conditions:
+          - condition: trigger
+            id:
+              - schedule_on
+              - alternate_on
+        sequence:
+          - action: switch.turn_on
+            target:
+              entity_id: !input navien_recirculation_switch
+      # Disable recirculation when both the schedule and alternate trigger are off.
+      - conditions:
+          - condition: and
+            conditions:
+              - condition: trigger
+                id:
+                  - schedule_off
+                  - alternate_off
+              - condition: template
+                value_template: "{{ schedule_and_alternate_are_off }}"
+        sequence:
+          - action: switch.turn_off
+            target:
+              entity_id: !input navien_recirculation_switch
+mode: single


### PR DESCRIPTION
This PR adds support for controlling when scheduled recirculation is active, which allows Home Assistant to replicate the weekly scheduling capability of the NaviLink app when the water heater is in one of the scheduled ("Always", "Intelligent", or "Weekly") modes. It has been tested against an NPE-240A2 water heater. It should hopefully work on other models as well.

Normally in these modes, if a NaviLink is connected, the water heater ignores its own internal scheduling and lets the NaviLink tell it when it should or should not be allowed to recirculate. This PR allows the ESPhome devices to do the same thing. A new switch "Allow Recirculation" is exposed in Home Assistant, which can be tied to automations to control what time of day recirculation should take place. And this PR also provides an example blueprint for automating a schedule.

As with the actual NaviLink, this new switch and the existing "Hot Button" button are mutually exclusive; the new switch only works if the water heater is in "Always", "Intelligent", or "Weekly" mode, and not if it's in "Hot Button" mode, and the opposite is still true for the "Hot Button" button. You can tell which one by looking at the "Recirculation Mode" sensor (which is slightly changed from the existing "Recirculation Status" sensor, see below) to tell which of the two will work; it will say `Scheduled` if the new switch works, or `HotButton` if the original button works.

## Protocol changes

This PR adds two new control packets: `SCHEDULED_RECIRC_ON_CMD` and `SCHEDULED_RECIRC_OFF_CMD`. The first one tells the Navien unit that it can recirculate when it sees fit (and also triggers an immediate recirculation cycle), and is what gets sent by NaviLink when either a scheduled recirculation time block begins, or when you turn off the weekly schedule (which puts the unit back into "always recirculate" mode). And the second is sent by NaviLink when a recirculation time block ends.

In water status packets, whether or not recirculation is enabled is represented by bit 1 of byte 33 (`recirculation_enabled`) being set, and sending these commands causes that bit to be set or cleared. When the unit is actively recirculating, this is reflected by `heating_mode` changing to 0x08 (`HEATING_MODE_DOMESTIC_HOT_WATER_RECIRCULATING`). The commands will set or clear that bit regardless of whether the unit is in "HotButton" mode or one of the three scheduled modes ("Always", "Intelligent", or "Weekly"). However if the unit is in "HotButton" mode, no actual recirculation will occur (although if you set the bit and then change the unit to one of the other three modes, recirculation will start). 

I also made two other protocol changes at the link level:

 * I re-enabled the sending of `NAVILINK_PRESENT` packets. These are needed because they are what signal to the water heater that it should stop trying to control its recirculation schedule itself and let our device do it; on an NPE-240A2, this is reflected on the control panel by the Navien saying "Recirculation settings must be configured through the NaviLink app" if you try to change between the three scheduled modes in the settings.
 * I added detection of `NAVILINK_PRESENT` packets coming from another device (in case an actual NaviLink is also connected). If such packets are detected, then the ESPHome device will stop sending its own `NAVLINK_PRESENT` packets, because they're redundant. It will also wait to send its command packets until after the NaviLink sends its presence packet, in an attempt to avoid bus collisions.

I did see that there's an existing but unused `RECIRC_ON` packet in `navilink_proto.h`, and some commented-out code in the `send_hot_button_cmd` method that references it. That packet is very similar to `SCHEDULED_RECIRC_ON_CMD`, except for a one byte difference that I've never seen from my NaviLink Lite. I wasn't sure what that different byte meant, so I left the packet definition there for posterity.

## Entity changes

From Home Assistant's perspective, the sending of these packets is controlled by a new switch, "Allow Recirculation". Several new sensors are also added by this PR:

 * "Scheduled Recirculation" is a binary sensor that will show "Running" if a recirculation cycle is active (it reflects whether the "Heating Mode" sensor is "DHW Recirculating"; I had coded it up before I had merged in the changes that added the "Heating Mode" sensor, so it is a little bit redundant)
 * "Hot Button Recirculation" is a binary sensor that will show "Running" if a HotButton-triggered recirculation cycle is active (which is indicated by bit 0 of `recirculation_enabled` being set. For whatever reason, a HotButton-triggered recirculation cycle just shows in `heating_mode` as "Domestic Hot Water", the same as if a tap was running.
 * "Other NaviLink Present" is a diagnostic binary sensor that will be on if another NaviLink appears to be sharing the bus with the ESPHome device. This is used by the automation (see below) so that it can let the user know the automation won't work in that situation. It seems that the NaviLink is rather possessive of its schedule; when the ESPHome tries to enable or disable scheduled recirculation, the NaviLink will immediately send its own commands to revert the mode back to whatever it thinks it should be.

In addition, I changed the "Recirculation Status" binary sensor to a text sensor named "Recirculation Mode", which will have the value `HotButton` or `Scheduled`, as that more accurately reflects the meaning of bit 1 of `system_status`.

Regarding the two "recirculation running" sensors, I debated whether to combine them into a single sensor, since they can't both ever be true at the same time, and the "scheduled recirculation" one by itself is a bit redundant with the recently-added "Heating Mode" sensor. I'm open to suggestions.

## Automation Blueprint

Last but not least, this PR includes a Home Assistant automation blueprint that allows the user to set up a recirculation schedule for their water heater, using a Schedule helper. It also allows for recirculation to be triggered by other switches or buttons (and for buttons, it will basically simulate the HotButton functionality by enabling recirculation until a single cycle completes).

The automation will check to ensure that the Navien is in the correct scheduling mode and will issue a notification if it's not. It will also issue a notification if another NaviLink device is detected, as a NaviLink will insist on trying to control the schedule and countermand any attempts by the ESPHome device to do so.