### PR TITLE
Add support for M5Stack AtomS3 Lite/Tail485

### DIFF
--- a/doc/240.md
+++ b/doc/240.md
@@ -37,3 +37,15 @@ This page is based on my research and experimentation, as well as contributions 
 | 5   | +5V     |
 
 I've used the +5V to supply power to esp-8266, appears to have enough for it.
+
+## 8 Pin RJ45 Connector (the one that comes with a NaviLink Lite)
+
+If you want to use the cable that comes with the NaviLink Lite to connect via an RJ45 breakout board, here's the mapping to the 5 Pin connector 1:
+
+| RJ45 Pin | Equiv. on connector 1 | Purpose   |
+|----------|-----------------------|-----------|
+| 1, 2     | 1                     | +13V?     |
+| 4        | 3                     | RS-485 A+ |
+| 5        | 2                     | RS-485 B- |
+| 7, 8     | 5                     | GND       |
+

--- a/esphome/navien-esphome-atoms3-lite-tail485-esp32.yml
+++ b/esphome/navien-esphome-atoms3-lite-tail485-esp32.yml
@@ -1,0 +1,116 @@
+# This configuration file is for an M5Stacks AtomS3-Lite with the Tail485 add-on.
+#
+# Tail485 wiring:
+#
+# | Tail485 | 5-pin connector #1 |
+# |---------|--------------------|
+# | B       | pin 2              |
+# | A       | pin 3              |
+# | 12V     | pin 1              |
+# | GND     | pin 5              |
+#
+# Confirm first that your Navien delivers +12V (give or take a volt) on pin 1 (true on an NPE-240-A2 at least)
+#
+# See [the 240 wiring docs](docs/240.md) for more info
+
+substitutions:
+  tx_pin: GPIO2
+  rx_pin: GPIO1
+  platform: esp32
+  board: m5stack-atoms3
+  friendly_name: Navien
+  project_name: Navien.AtomS3-Lite-Tail485-ESP32
+  project_version: "0.0.0.1"
+
+esp32:
+  framework:
+    type: esp-idf
+    
+packages:
+  navien: !include navien-base.yml
+  sensors: !include navien-sensors.yml
+
+logger:
+  level: INFO
+  baud_rate: 0 #disable logging over uart
+
+dashboard_import:
+  package_import_url: github://htumanyan/navien/esphome/navien-esphome-atoms3-lite-tail485-esp32.yml
+  import_full_config: false
+
+button:
+  - platform: navien
+    name: ${friendly_name} Hot Button
+
+light:
+  - platform: esp32_rmt_led_strip
+    internal: true
+    chipset: WS2812
+    pin: GPIO35
+    num_leds: 1
+    rgb_order: GRB
+    id: led
+    name: "Indicator Light"
+
+# This exposes the button on the Atom S3 Lite itself as a button in Home Assistant, for use as
+# whatever you want. If you don't want it, you can comment this block out.
+binary_sensor:
+  - platform: gpio
+    id: atom_s3_lite_button
+    name: "Atom S3 Lite Button"
+    pin:
+      number: GPIO41
+      inverted: true
+      mode:
+        input: true
+        pullup: true
+    filters:
+      - delayed_off: 10ms
+    on_press:
+      - lambda: |-
+          ESP_LOGI("binary_sensor.atom_s3_lite_button", "Pressed");
+
+# LED behavior:
+#  at power on: yellow
+#  at wifi connected: green
+#  at wifi disconnect: red
+#  at shutdown: blue
+
+esphome:
+  on_boot:
+    priority: 500
+    then:
+      - light.turn_on:
+          id: led
+          brightness: 80%
+          red: 100%
+          green: 100%
+          blue: 0%
+  on_shutdown:
+    priority: -100
+    then:
+      - light.turn_on:
+          id: led
+          brightness: 80%
+          red: 0%
+          green: 0%
+          blue: 100%
+        
+wifi:
+  on_connect:
+    then:
+      - light.turn_on:
+          id: led
+          brightness: 80%
+          red: 0%
+          green: 100%
+          blue: 0%
+  on_disconnect:
+    then:
+      - light.turn_on:
+          id: led
+          brightness: 80%
+          red: 100%
+          green: 0%
+          blue: 0%
+      


### PR DESCRIPTION
Adds a configuration file for the [AtomS3 Lite](https://docs.m5stack.com/en/core/AtomS3%20Lite) with a [Tail485 ](https://docs.m5stack.com/en/atom/tail485) adapter. This configuration file also exposes the button on the S3 Lite as an extra button in Home Assistant, for whatever random use people want it for.

I also added some info to `doc/240.md` about pin mapping between the 5-pin connector 1 and the NaviLink RJ45 cable (via an RJ45 breakout board), since that's how I have mine hooked up.