### PR TITLE
Fix Fahrenheit rounding issues

### DIFF
--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -97,21 +97,21 @@ namespace navien {
 
   typedef struct{
     struct{
-      uint8_t set_temp;
-      uint8_t outlet_temp;
-      uint8_t inlet_temp;
+      float set_temp;
+      float outlet_temp;
+      float inlet_temp;
       float flow_lpm;
       uint8_t utilization;
       bool boiler_active;
     } water;
     struct{
-      uint8_t  set_temp;
-      uint8_t  outlet_temp;
-      uint8_t  inlet_temp;
+      float  set_temp;
+      float  outlet_temp;
+      float  inlet_temp;
       uint16_t accumulated_gas_usage;
       uint16_t current_gas_usage;
-      uint8_t  sh_outlet_temp; // combi (and space heat?) models
-      uint8_t  sh_return_temp; // combi (and space heat?) models
+      float  sh_outlet_temp; // combi (and space heat?) models
+      float  sh_return_temp; // combi (and space heat?) models
       uint8_t heat_capacity;
       uint16_t total_dhw_usage;
       uint16_t total_operating_time;

--- a/esphome/components/navien/navien_link.cpp
+++ b/esphome/components/navien/navien_link.cpp
@@ -201,7 +201,7 @@ void NavienLink::send_hot_button_cmd(){
 void NavienLink::send_set_temp_cmd(float temp){
   uint8_t cmd[19];
   memcpy(cmd, SET_TEMP_CMD_TEMPLATE, sizeof(SET_TEMP_CMD_TEMPLATE));
-  cmd[9] = temp * 2;
+  cmd[9] = temp * 2 + 0.5;
   cmd[18] = NavienLink::checksum(cmd, sizeof(SET_TEMP_CMD_TEMPLATE) - 1, CHECKSUM_SEED_62);
 
   NavienLink::print_buffer(cmd, sizeof(SET_TEMP_CMD_TEMPLATE));
@@ -226,7 +226,7 @@ float NavienLink::flow2gpm(uint8_t f){
   return  (float)f / 10.f / 3.785f;
 }
 
-uint8_t NavienLink::t2c(uint8_t c){
+float NavienLink::t2c(uint8_t c){
   return (float)c / 2.f;
 }
   

--- a/esphome/components/navien/navien_link.h
+++ b/esphome/components/navien/navien_link.h
@@ -121,7 +121,7 @@ public:
 
   static uint8_t t2f(uint8_t);
   static float flow2gpm(uint8_t f);
-  static uint8_t t2c(uint8_t);
+  static float t2c(uint8_t);
   static float flow2lpm(uint8_t f);
 
 protected:


### PR DESCRIPTION
I took a stab at fixing the Fahrenheit drift issue (#13). For me it seems to be working, at least for all the temps between 100 and 120 degrees.

The fix I did was two parts:
1. On the "set temperature" command to the Navien, when converting from Fahrenheit to double-Celsius, round up when converting the double-Celsius value to an integer. This makes sure that the double-Celsius value we set the Navien to corresponds to the right Fahrenheit value when the machine displays it.
2. On the reporting side, in the status structure in navien.cpp, store the Celsius values as floats so that the half-steps aren't lost after dividing the Navien's value by two.

So taking 120 degrees F as an example:

Before the fix, we would have sent int((120-32)/9*5*2) = 97 to the Navien, which it would have interpreted as 119.3 (97*9/10+32), and rounded down to 119. And then the 97 it told back to us would have been saved as 48C (not 48.5), which Home Assistant would then report as 118.4 (or maybe just 118 depending on where you were looking). Oops!

Now, for 120F, we send 98 to the Navien ( (120-32)/9*10 = 97.7, rounded up is 98).  98 happens to be even so on the way back to HA that would have converted correctly. 

But for 119F, we now send 97 to the Navien, which it will correctly interpret as 119F. But on the way back, as I said above, we would have converted that to 48C, which HA would have shown as 118.  Now, we convert it to 48.5C instead, which HA will properly round to 119F. 
