### PR TITLE
Correct gas total and current units to CCF and kW, rather than Therms and BTU.

### DIFF
--- a/esphome/components/navien/sensor.py
+++ b/esphome/components/navien/sensor.py
@@ -109,7 +109,6 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_GAS_TOTAL): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CUBIC_METER,
                 accuracy_decimals=2,
-                device_class=DEVICE_CLASS_GAS,
                 state_class=STATE_CLASS_TOTAL_INCREASING,
             ),
             cv.Optional(CONF_GAS_CURRENT): sensor.sensor_schema(

--- a/esphome/navien-sensors.yml
+++ b/esphome/navien-sensors.yml
@@ -84,18 +84,23 @@ sensor:
       unit_of_measurement: "%"
       accuracy_decimals: 1
     gas_total:
+      id: gas_total_therms
       name: "${friendly_name} Accumulated Gas Usage${sensor_suffix}"
+      # Navien reports accumulated gas in m³/10.
+      # 1 m³ gas = 9131 kcal; 1 Therm = 25193 kcal.
       filters:
         - lambda: return x * 9131.0 / 25193.0 / 10.0;
       unit_of_measurement: "Therms"
       accuracy_decimals: 1
     gas_current:
+      id: gas_current_btu
       name: "${friendly_name} Current Gas Usage${sensor_suffix}"
+      # Navien reports instantaneous gas usage in 10x kcal/hr.
+      # 1 kcal = 3.968 BTU; the 10x factor is confirmed by comparing
+      # against the reported heat capacity percentage.
       filters:
         - lambda: return x * 3.9680;
       unit_of_measurement: "BTU"
-      device_class: power
-      state_class: measurement
       accuracy_decimals: 1
     total_dhw_usage:
       name: "${friendly_name} Total DHW Uses${sensor_suffix}"
@@ -127,4 +132,35 @@ sensor:
     # this will be true if another NaviLink device is also connected
     other_navilink_installed:
       id: other_navilink_installed
-      name: "${friendly_name} Other NaviLink Installed${sensor_suffix}"  
+      name: "${friendly_name} Other NaviLink Installed${sensor_suffix}"
+
+  # HA-compatible gas sensors. These are disabled by default; enable them in
+  # the ESPHome integration if you want Energy Dashboard compatibility.
+  #
+  # "Therms" is not a valid HA unit for device_class gas, so we provide CCF.
+  # 1 CCF ~= 1.038 Therms.
+  - platform: copy
+    source_id: gas_total_therms
+    name: "${friendly_name} Accumulated Gas Usage CCF${sensor_suffix}"
+    unit_of_measurement: "CCF"
+    device_class: gas
+    state_class: total_increasing
+    filters:
+      - lambda: return x / 1.038;
+    accuracy_decimals: 1
+    disabled_by_default: true
+
+  # Instantaneous gas usage in kW (power, not energy).
+  # The legacy BTU sensor value is 1/10 of actual BTU/hr (see gas_current
+  # comments above), so we correct by 10x and convert BTU/hr to kW.
+  # 1 kW = 3412 BTU/hr.
+  - platform: copy
+    source_id: gas_current_btu
+    name: "${friendly_name} Current Gas Usage kW${sensor_suffix}"
+    unit_of_measurement: "kW"
+    device_class: power
+    state_class: measurement
+    filters:
+      - lambda: return x * 10.0 / 3412.0;
+    accuracy_decimals: 1
+    disabled_by_default: true


### PR DESCRIPTION
This pull request includes two changes:

1. Home Assistant doesn't accept Therms as a unit; this pull request converts them to CCF at 1 CCF ~= 1.038 Therms.
2. `gas_current` is a power measurement, not energy. The input unit, on my 240/130H, appears to be BTU/min — that is, when my hot water is running it spikes to about 3,000 — and so we can convert that to kW by multiplying by 60 (BTU/h) then dividing by 3412.

The Navien 240/130H is [documented](https://www.navieninc.com/products/ncb-240-130h) as having peak DHW of 199,900 BTU/h, so the interpretation of 3,000 as BTU/min makes sense. I now observe that each kW of `gas_current` corresponds to about 1.16% of "heating capacity", implying a total max power of about 85kW; this aligns with the numbers in Navien's docs of 38.09kWh + 58.57kWh (they mean kW).