### PR TITLE
Consolidate recirculation running sensors and fix mode detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,28 @@ bash esphome run navien-wrd-hb.yml
 
 ---
 
+### 8. Importing the Scheduled Recirculation Automation Blueprint
+
+If you have a unit, such as the NPE2 series, that supports scheduled recirculation (meaning it has recirculation modes named something like "Always", "Intelligent", "Weekly", etc), and setting your unit to one of those modes results in the "Navien Recirculation Mode" sensor in Home Assistant reporting "External Scheduled" or "Internal Scheduled", then you can likely use the automation blueprint for scheduling your unit's recirculation times. To do that:
+
+First, you need to create a Schedule entity that will control when circulation is active:
+
+1. In Home Assistant, go to "Settings", "Devices and Services"
+2. Click "Add integration"
+3. Find "Schedule (helper)" and select it
+4. Give the schedule a name like "Navien Recirculation", and set up the schedule (or you can do that part later)
+5. Click "Create"
+
+Then, set up the automation:
+
+1. In Home Assistant, go to "Settings", "Automations & scenes", then to the "Blueprints" tab.
+2. Click "Import Blueprint" in the lower-right corner
+3. Enter Blueprint address: `https://raw.githubusercontent.com/htumanyan/navien/refs/heads/main/navien_schedule_automation_blueprint.yaml`
+4. Click "Preview", then "Import blueprint"
+5. In the list of blueprints, "Navien Scheduled Recirculation" should now appear. Click it.
+6. Fill in all the values per the directions (you might need to create some more helper entities depending on how you want to do things)
+7. Click "Save" and give the new automation a name.
+
 ### 📖 User Manual for Custom Navien Controller
 
 For detailed instructions on connecting, configuring, and using the custom Navien controller device, see the [User Manual](./user_manual.md). This guide covers hardware setup, wiring, and usage tips specific to the custom controller.

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -39,8 +39,11 @@ namespace navien {
 
   
   typedef enum _DEVICE_RECIRC_MODE{
-    HOTBUTTON,
-    SCHEDULED
+    RECIRC_UNKNOWN,
+    RECIRC_OFF,
+    RECIRC_EXT_HOTBUTTON,
+    RECIRC_EXT_SCHEDULED,
+    RECIRC_INT_SCHEDULED,
   } DEVICE_RECIRC_MODE;
 
   typedef enum _DEVICE_UNITS{
@@ -93,6 +96,7 @@ namespace navien {
     FLAME_OFF = 0x3C,
     POST_PURGE_1 = 0x46,
     POST_PURGE_2 = 0x47,
+    SHUTTING_DOWN = 0x48,
     DHW_WAIT = 0x49 //DHW Wait / Set Point Match depending on model
   } OPERATING_STATE;
 
@@ -105,8 +109,7 @@ namespace navien {
       uint8_t utilization;
       bool boiler_active;
       bool scheduled_recirc_allowed;
-      bool hotbutton_recirc_running;
-      bool scheduled_recirc_running;
+      bool recirc_running;
     } water;
     struct{
       float  set_temp;
@@ -135,6 +138,7 @@ namespace navien {
     DEVICE_POWER_STATE  power;
     DEVICE_RECIRC_MODE  recirculation;
     DEVICE_UNITS        units;
+    bool hotbutton_mode_enabled;  // From GAS packet - true if HotButton mode is configured
   } NAVIEN_STATE;
 
 
@@ -172,8 +176,7 @@ namespace navien {
     void set_gas_outlet_temp_sensor(sensor::Sensor *sensor) { gas_outlet_temp_sensor = sensor; }
     void set_water_flow_sensor(sensor::Sensor *sensor) { water_flow_sensor = sensor; }
     void set_water_utilization_sensor(sensor::Sensor *sensor) { water_utilization_sensor = sensor; }
-    void set_scheduled_recirc_running_sensor(binary_sensor::BinarySensor *sensor) { scheduled_recirc_running_sensor = sensor; }
-    void set_hotbutton_recirc_running_sensor(binary_sensor::BinarySensor *sensor) { hotbutton_recirc_running_sensor = sensor; }
+    void set_recirc_running_sensor(binary_sensor::BinarySensor *sensor) { recirc_running_sensor = sensor; }
     void set_gas_total_sensor(sensor::Sensor *sensor) { gas_total_sensor = sensor; }
     void set_gas_current_sensor(sensor::Sensor *sensor) { gas_current_sensor = sensor; }
     void set_device_type_sensor(text_sensor::TextSensor *sensor) { device_type_sensor = sensor; }
@@ -251,8 +254,7 @@ namespace navien {
 
     binary_sensor::BinarySensor *boiler_active_sensor = nullptr;
     binary_sensor::BinarySensor *conn_status_sensor = nullptr;
-    binary_sensor::BinarySensor *scheduled_recirc_running_sensor = nullptr;
-    binary_sensor::BinarySensor *hotbutton_recirc_running_sensor = nullptr;
+    binary_sensor::BinarySensor *recirc_running_sensor = nullptr;
     binary_sensor::BinarySensor *other_navilink_installed_sensor = nullptr;
 
     switch_::Switch *power_switch = nullptr;

--- a/esphome/components/navien/sensor.py
+++ b/esphome/components/navien/sensor.py
@@ -49,8 +49,7 @@ CONF_GAS_TOTAL          = "gas_total"
 CONF_GAS_CURRENT        = "gas_current"
 CONF_SH_OUTLET_TEMPERATURE = "sh_outlet_temperature"
 CONF_SH_RETURN_TEMPERATURE = "sh_return_temperature"
-CONF_SCHEDULED_RECIRC_RUNNING = "scheduled_recirc_running"
-CONF_HOTBUTTON_RECIRC_RUNNING = "hotbutton_recirc_running"
+CONF_RECIRC_RUNNING = "recirc_running"
 
 CONF_CONN_STATUS        = "conn_status"
 CONF_REAL_TIME          = "real_time"
@@ -94,10 +93,7 @@ CONFIG_SCHEMA = cv.All(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=2,
             ),
-            cv.Optional(CONF_SCHEDULED_RECIRC_RUNNING): binary_sensor.binary_sensor_schema(
-                device_class = DEVICE_CLASS_RUNNING
-            ),
-            cv.Optional(CONF_HOTBUTTON_RECIRC_RUNNING): binary_sensor.binary_sensor_schema(
+            cv.Optional(CONF_RECIRC_RUNNING): binary_sensor.binary_sensor_schema(
                 device_class = DEVICE_CLASS_RUNNING
             ),
             cv.Optional(CONF_GAS_TOTAL): sensor.sensor_schema(
@@ -217,15 +213,10 @@ async def to_code(config):
         cg.add(sens.set_icon(config[CONF_WATER_UTILIZATION].get(CONF_ICON, "mdi:water-percent")))
         cg.add(var.set_water_utilization_sensor(sens))
 
-    if CONF_SCHEDULED_RECIRC_RUNNING in config:
-        sens = await binary_sensor.new_binary_sensor(config[CONF_SCHEDULED_RECIRC_RUNNING])
-        cg.add(sens.set_icon(config[CONF_SCHEDULED_RECIRC_RUNNING].get(CONF_ICON, "mdi:water-sync")))
-        cg.add(var.set_scheduled_recirc_running_sensor(sens))
-
-    if CONF_HOTBUTTON_RECIRC_RUNNING in config:
-        sens = await binary_sensor.new_binary_sensor(config[CONF_HOTBUTTON_RECIRC_RUNNING])
-        cg.add(sens.set_icon(config[CONF_HOTBUTTON_RECIRC_RUNNING].get(CONF_ICON, "mdi:water-sync")))
-        cg.add(var.set_hotbutton_recirc_running_sensor(sens))
+    if CONF_RECIRC_RUNNING in config:
+        sens = await binary_sensor.new_binary_sensor(config[CONF_RECIRC_RUNNING])
+        cg.add(sens.set_icon(config[CONF_RECIRC_RUNNING].get(CONF_ICON, "mdi:water-sync")))
+        cg.add(var.set_recirc_running_sensor(sens))
         
     if CONF_GAS_TOTAL in config:
         sens = await sensor.new_sensor(config[CONF_GAS_TOTAL])

--- a/esphome/navien-sensors.yml
+++ b/esphome/navien-sensors.yml
@@ -110,12 +110,9 @@ sensor:
     boiler_active:
       id: boiler_active
       name: "${friendly_name} Boiler Active${sensor_suffix}"
-    hotbutton_recirc_running:
-      id: hotbutton_recirc_running
-      name: "${friendly_name} Hot Button Recirculation${sensor_suffix}"
-    scheduled_recirc_running:
-      id: scheduled_recirc_running
-      name: "${friendly_name} Scheduled Recirculation${sensor_suffix}"
+    recirc_running:
+      id: recirc_running
+      name: "${friendly_name} Recirculation Running${sensor_suffix}"
     # this will be true if another NaviLink device is also connected
     other_navilink_installed:
       id: other_navilink_installed

--- a/navien_schedule_automation_blueprint.yaml
+++ b/navien_schedule_automation_blueprint.yaml
@@ -6,7 +6,7 @@ blueprint:
     This automation only works if your Navien water heater is configured to use scheduled ("Always On", "Intelligent",
     or "Weekly") recirculation. It will not work if the water heater is configured for "HotButton" recirculation.
 
-    Version: 1.0.1
+    Version: 1.1.0
   domain: automation
   input:
     recirculation_schedule:
@@ -27,10 +27,10 @@ blueprint:
           filter:
             - domain: switch
               integration: esphome
-    navien_circulating:
-      name: Navien Scheduled Recirculation
+    navien_recirculating:
+      name: Navien Recirculation Running
       description: >
-        Set this to the "Scheduled Recirculation" sensor from your Navien device. This indicates if the Navien is 
+        Set this to the "Recirculation Running" sensor from your Navien device. This indicates if the Navien is 
         actively recirculating water.
       selector:
         entity:
@@ -84,7 +84,9 @@ blueprint:
 trigger_variables:
   schedule_entity: !input recirculation_schedule
   alternate_entity: !input alternate_recirculation_switch
+  navien_hotbutton: !input navien_hotbutton
 variables:
+  navien_recirculating: !input navien_recirculating
   schedule_and_alternate_are_off: >
     {{ is_state(schedule_entity, 'off') and (alternate_entity == "" or is_state(alternate_entity, 'off')) }}
   navien_mode: !input navien_mode
@@ -110,13 +112,20 @@ triggers:
   - trigger: state
     id: hotbutton
     entity_id: !input navien_hotbutton
+  # Trigger when recirculating stops to see if the schedule should stay enabled or be disabled.
+  # This takes care of turning the schedule back off after a hot button trigger while it was off.
+  - trigger: state
+    id: recirculating_off
+    entity_id: !input navien_recirculating
+    from: "on"
+    to: "off"
 actions:
   # Complain if the Navien is in the wrong mode. But keep going, because the Navien will remember the state
   # of "Allow Recirculation" even if it's in the wrong mode, and recirculation will start if the user fixes it.
   - if:
       - condition: template
         value_template: >-
-          {{ not is_state(navien_mode, 'Scheduled') }}
+          {{ is_state(navien_mode, 'Off') or is_state(navien_mode, 'External HotButton') }}
     then:
       - service: persistent_notification.create
         data:
@@ -147,6 +156,9 @@ actions:
       - conditions:
           - condition: trigger
             id: hotbutton
+          - condition: template
+            value_template: >-
+              {{ trigger.from_state.state not in ['unknown', 'unavailable'] and trigger.to_state.state not in ['unknown', 'unavailable'] }}
         sequence:
           # If scheduled recirculation is enabled, disable it first. Disabling and re-enabling it will trigger a 
           # recirculation cycle.
@@ -168,18 +180,6 @@ actions:
             target:
               entity_id: !input navien_recirculation_switch
             data: {}
-          # Wait for the recirculation cycle to finish.
-          - wait_for_trigger:
-              - trigger: state
-                entity_id: !input navien_circulating
-                from: "on"
-                to: "off"
-          # Stop here if recirculation is supposed to be on right now, leaving it on.
-          - condition: template
-            value_template: "{{ schedule_and_alternate_are_off }}"
-          - action: switch.turn_off
-            target:
-              entity_id: !input navien_recirculation_switch
       # Enable recirculation when either the schedule or alternate trigger turns on.
       - conditions:
           - condition: trigger
@@ -192,14 +192,8 @@ actions:
               entity_id: !input navien_recirculation_switch
       # Disable recirculation when both the schedule and alternate trigger are off.
       - conditions:
-          - condition: and
-            conditions:
-              - condition: trigger
-                id:
-                  - schedule_off
-                  - alternate_off
-              - condition: template
-                value_template: "{{ schedule_and_alternate_are_off }}"
+          - condition: template
+            value_template: "{{ schedule_and_alternate_are_off }}"
         sequence:
           - action: switch.turn_off
             target:


### PR DESCRIPTION
Per discoveries that were discussed between me, @mikeygnyc, and @htumanyan in #23, I've made some fixes to my previous PR #22 for scheduled recirculation.

## Fixes

- Merged the `scheduled_recirc_running` and `hotbutton_recirc_running` sensors into a single `recirc_running` sensor (since they were mutually exclusive anyway)
- Fixed mode detection to check both bit 0 (internal) and bit 1 (external) of the water packet `system_status` byte for scheduled recirculation modes
- Added the `RECIRC_OFF` state to distinguish recirculation completely disabled from HotButton mode; also renamed the other constants in the same enum to have the `RECIRC` prefix for consistency
- HotButton mode on/off is now detected from gas packet byte 21 bit 2 (which has been renamed from `unknown_20` to `system_status_2`, for lack of a better name)
- Expanded the `recirc_mode` sensor text values to show: "Off", "External HotButton", "External Scheduled", or "Internal Scheduled" in Home Assistant
- Updated the automation blueprint to reflect the new `recirc_running` sensor name
- Fixed the automation blueprint to not trigger a hot button sequence if the actual button transitions to or from "unknown" or "unavailable" (which happens when new code is being uploaded to the ESPHome device)
- Fixed a bug in the hot button branch of the automation where it would stall due to a race condition on recirculation finishing before the step that checked for it
- Fixed the `POWER_STATUS_ON_OFF_MASK` from `0x05` to `0x01`, per PR #23
- Added `SHUTTING_DOWN` (`0x48`) value to `_OPERATING_STATE` enum, and update the text conversion function accordingly, per PR #23
- Detect whether the unit is using Celsius or Fahrenheit based on gas packet data instead of water packet data, as it seems to be more consistent between different unit types
- Added cases for reading `recirc_running` from `system_power` bit 5 for NCB_H units
- Added the `RECIRC_UNKNOWN` state, for NCB_H units as they don't seem to report their recirculation mode
- Added instructions to `README.md` on how to set up the automation

## Breaking changes:

### Home Assistant entities changed:
- Removed: binary_sensor.*_hot_button_recirculation
- Removed: binary_sensor.*_scheduled_recirculation
- Added: binary_sensor.*_recirculation_running

### Automation Blueprint:
- To update automations, go to the Blueprints settings screen in Home Assistant, find the blueprint, click the three-dots icon, and select "Re-import blueprint"
- Due to the above entity changes, you will need to go into actual instances of the automation and re-select the "Recirculation Running" sensor (regardless of whether you import the new blueprint version or not)