### PR TITLE
Move NavienLinkEsp to be represented in config

### DIFF
--- a/esphome/navien-sensors.yml
+++ b/esphome/navien-sensors.yml
@@ -30,10 +30,10 @@ text_sensor:
 
 sensor:
   - platform: navien
+    type: navien_link
+  - platform: navien
     id: navien_main
-    src: 0
     name: "${friendly_name} Metrics"
-    uart_id: main_hw_uart
     target_temperature:
       id: navien_target_temperature
       name: "${friendly_name} Target Temp${sensor_suffix}"

--- a/esphome/navien.yml
+++ b/esphome/navien.yml
@@ -85,8 +85,10 @@ sensor:
   - platform: wifi_signal
     name: $friendly_name wifi signal
   - platform: navien
-    name: $friendly_name Test sensor
+    type: navien_link
     uart_id: main_hw_uart
+  - platform: navien
+    name: $friendly_name Test sensor
     target_temperature:
       name: $friendly_name Target Temp
       filters:


### PR DESCRIPTION
Culmination of the investigation in #33 concluded that to keep NavienEspLink as a separate singleton it needed to be represented in config as a distinct component due to esphome behavior changes.

As this is only a config and code gen change, none of the actual implementation logic needed adjusted.

However, this is unfortunately a **breaking change**  for all existing configs. The required update is simple, but non-zero:
```
sensor:
  - platform: navien
    uart_id: main_hw_uart
    <...>
```
to
```
sensor:
  - platform: navien
    type: navien_link
    uart_id: main_hw_uart
  - platform: navien
  <...>
```

Possible alternatives:
1. Make this change (ie config schema and code gen) esphome version aware, keeping existing behavior for < 2026.1.0
2. Revert to a state that looks more like things pre bd6521f 

I presume (2) would make cascade support less convenient(?), but happy to refactor things for (1) if the additional complexity in `sensor.py` is preferable to a breaking change.

I've confirmed this change works on both 2025.12.7 and esphome 2026.1.3 and have been running with the latter successfully for the past couple days.