### PR TITLE
Support configuration without switch or climate components

### DIFF
--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -238,35 +238,28 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
       this->recirc_running_sensor->publish_state(this->state.water.recirc_running);
     }
 
+#ifdef USE_CLIMATE
     // Update the climate control with the current target temperature
     if (this->climate != nullptr){
+      switch(this->state.power){
+      case POWER_ON:
+        this->climate->mode = climate::ClimateMode::CLIMATE_MODE_HEAT;
+        break;
+      default:
+        this->climate->mode = climate::ClimateMode::CLIMATE_MODE_OFF;
+      }
+
       this->climate->current_temperature = this->state.water.outlet_temp;
       this->climate->target_temperature = this->state.water.set_temp;
       this->climate->publish_state();
     }
+#endif
 
     if (this->recirc_mode_sensor != nullptr) {
       this->recirc_mode_sensor->publish_state(device_recirc_mode_to_str(this->state.recirculation));
     }
 
-    switch(this->state.power){
-    case POWER_ON:
-      if (this->power_switch != nullptr)
-        this->power_switch->publish_state(true);
-      if (this->climate != nullptr){
-        this->climate->mode = climate::ClimateMode::CLIMATE_MODE_HEAT;
-        this->climate->publish_state();
-      }
-      break;
-    default:
-      if (this->power_switch != nullptr)
-        this->power_switch->publish_state(false);
-      if (this->climate != nullptr){
-        this->climate->mode = climate::ClimateMode::CLIMATE_MODE_OFF;
-        this->climate->publish_state();
-      }
-    }
-
+#ifdef USE_SWITCH
     if (this->power_switch != nullptr){
       switch(this->state.power){
       case POWER_ON:
@@ -280,6 +273,7 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
     if (this->allow_recirc_switch != nullptr){
       this->allow_recirc_switch->publish_state(this->state.water.scheduled_recirc_allowed);
     }
+#endif
 
     if (this->target_temp_sensor != nullptr)
       this->target_temp_sensor->publish_state(this->state.water.set_temp);
@@ -297,12 +291,12 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
     if (this->target_temp_sensor != nullptr)
       this->target_temp_sensor->publish_state(this->state.gas.set_temp);
 
+#ifdef USE_CLIMATE
     // Update the climate control with the current target temperature
     if (this->climate != nullptr){
-      //    this->climate->current_temperature = this->state.gas.outlet_temp * 9.f / 5.f + 32.f;
-      //this->climate->target_temperature = this->state.gas.set_temp * 9.f / 5.f + 32.f;
       this->climate->publish_state();
     }
+#endif
   
   if (this->outlet_temp_sensor != nullptr)
     this->outlet_temp_sensor->publish_state(this->state.gas.outlet_temp);

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -4,31 +4,21 @@
 #include <list>
 
 #include "esphome/core/component.h"
-//#ifdef USE_SENSOR
 #include "esphome/components/sensor/sensor.h"
-//#endif
-
-//#ifdef USE_BINARY_SENSOR
 #include "esphome/components/binary_sensor/binary_sensor.h"
-//#endif
 #include "esphome/components/text_sensor/text_sensor.h"
-
-//#ifdef USE_SWITCH
-#include "esphome/components/switch/switch.h"
-//#endif
 #include "esphome/components/uart/uart.h"
+
+#ifdef USE_CLIMATE
+#include "esphome/components/climate/climate.h"
+#endif
+
+#ifdef USE_SWITCH
+#include "esphome/components/switch/switch.h"
+#endif
+
 #include "navien_link.h"
 #include "navien_proto.h"
-#include "esphome/components/climate/climate.h"
-#include "esphome/components/text_sensor/text_sensor.h"
-
-// #include "navien_link_esp.h" // No longer needed
-
-#ifndef USE_SWITCH
-namespace switch_ {
-class Switch;
-}
-#endif
 
 namespace esphome {
 namespace navien {
@@ -195,6 +185,7 @@ namespace navien {
     void set_cumulative_domestic_usage_cnt_sensor(sensor::Sensor *sensor) { cumulative_domestic_usage_cnt_sensor = sensor; }
     void set_other_navilink_installed_sensor(binary_sensor::BinarySensor *sensor) { other_navilink_installed_sensor = sensor; }
 
+#ifdef USE_SWITCH
     /**
      * Sets the power switch component that will be notified of power
      * state changes, i.e. if the unit goes off, Navien will update the switch to reflect that
@@ -206,14 +197,11 @@ namespace navien {
      * when scheduled recirculation is active or inactive
      */
     void set_allow_recirc_switch(switch_::Switch * rs){allow_recirc_switch = rs;}
+#endif
 
+#ifdef USE_CLIMATE
     void set_climate(climate::Climate * c){climate = c;}
-
-    /**
-     * Sets the climate component that will be receiving temperature updates
-     */
-    //void set_climate(switch_::Switch * ps){power_switch = ps;}
-
+#endif
 
   protected:
     /**
@@ -252,9 +240,14 @@ namespace navien {
     binary_sensor::BinarySensor *recirc_running_sensor = nullptr;
     binary_sensor::BinarySensor *other_navilink_installed_sensor = nullptr;
 
+#ifdef USE_SWITCH
     switch_::Switch *power_switch = nullptr;
     switch_::Switch *allow_recirc_switch = nullptr;
+#endif
+
+#ifdef USE_CLIMATE
     climate::Climate *climate = nullptr;
+#endif
 
     NavienLink *navien_link_;
     esphome::uart::UARTComponent* uart_;


### PR DESCRIPTION
This change should be a noop for existing configs.

However, this does allow new configs to eliminate these if not desired (and looking slightly ahead to #35 where Climate usage will likely be superseded).

Started down the path of the same for text sensors, but there is one text sensor defined in `sensor.py` (`recirc_mode`) already that would make doing that in a backwards compatible way more interesting. Similar situation for sensor and binary_sensor as well.