### PR TITLE
Move controller_version_hi and panel_version_hi fields back to unknown

### DIFF
--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -188,13 +188,13 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
       this->state.units = CELSIUS;
     }
 
-    std::string contVers = std::to_string(gas.controller_version_lo);
+    std::string contVers = std::to_string(gas.controller_version);
     if (contVers.length() < 2){
       contVers.insert(0, 2 - contVers.length(), '0');
     }
     this->state.controller_version = contVers.substr(0, 1) + "." + contVers.substr(1, 1);
 
-    std::string panVers = std::to_string(gas.panel_version_lo);
+    std::string panVers = std::to_string(gas.panel_version);
     if (panVers.length() < 2){
       panVers.insert(0, 2 - panVers.length(), '0');
     }

--- a/esphome/components/navien/navien_proto.h
+++ b/esphome/components/navien/navien_proto.h
@@ -232,11 +232,11 @@ typedef struct {
   uint8_t  unknown_07; // 0x00
   uint8_t  device_type;
   uint8_t  unknown_09; //0x01 on NCB-H models
-  uint8_t  controller_version_lo;
-  uint8_t  controller_version_hi;
+  uint8_t  controller_version;
+  uint8_t  unknown_11;
 
-  uint8_t  panel_version_lo;
-  uint8_t  panel_version_hi;
+  uint8_t  panel_version;
+  uint8_t  unknown_13;
 
   uint8_t  set_temp;
   uint8_t  outlet_temp;


### PR DESCRIPTION
These have not been used since the refactor in 04631a8.

Half of the unknown field number were inconsistent in both the water and gas structs. Fix that up while adding back two unknown fields.