### PR TITLE
Restore sending of `NAVILINK_PRESENT` packets

### DIFF
--- a/esphome/components/navien/navien_link.cpp
+++ b/esphome/components/navien/navien_link.cpp
@@ -199,11 +199,14 @@ void NavienLink::receive() {
             // NavienLink::print_buffer(cmd.buffer, cmd.len);
           }
         } else {
-          if (!this->other_navilink_installed
-              && this->recv_buffer.hdr.len == NAVILINK_PRESENT[offsetof(HEADER, len)]
-              && std::memcmp(this->recv_buffer.raw_data, NAVILINK_PRESENT, sizeof(NAVILINK_PRESENT)) == 0) {
-            ESP_LOGW(TAG, "Detected NAVILINK_PRESENT packet from another NaviLink device, will stop sending NAVILINK_PRESENT packets until rebooted %d", sizeof(NAVILINK_PRESENT));
-            this->other_navilink_installed = true;
+          if (!this->other_navilink_installed) {
+            // If there's no pending command, send a NAVILINK_PRESENT packet so the unit knows we're here.
+            // When the unit is in an automatic recirculation mode, this tell is that we're controlling 
+            // when it does and does not recirculate (and it triggers the "Recirculation settings must be 
+            // configured through the NaviLink app" message on the unit's front panel when you try to
+            // change the recirculation setting)
+            uart->write_array(NAVILINK_PRESENT, sizeof(NAVILINK_PRESENT));
+            // NavienLink::print_buffer(NAVILINK_PRESENT, sizeof(NAVILINK_PRESENT));
           }
           this->on_error();
         }


### PR DESCRIPTION
This PR restores the sending of `NAVILINK_PRESENT` packets, which are needed in scheduled mode in order to tell an NPE-A2 device that it should let their recirculation schedule be controlled by the ESPhome device and not its own internal logic.

~This also moves the `on_error` call to where I think it should be; where it was originally would result in it being called anytime there was no command pending to be sent. In the process of testing this I had added a log message to receiving `on_error` method (which resulted in it being logged a lot before the fix); I left it there for now as it shouldn't be logged anymore after the fix.~ This change has been migrated to #42 

This fixes #37 .