### PR TITLE
Move receive to loop to fix RS-485 timing

### DIFF
--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -343,13 +343,14 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
       this->panel_version_sensor->publish_state(this->state.panel_version);
   }
 
-  void Navien::update() {
-    ESP_LOGV(TAG, "Conn Status: received: %d, updated: %d", this->received_cnt, this->updated_cnt);
-
-    // Call receive on navien_link_ to process UART data
+  void Navien::loop() {
     if (navien_link_) {
       navien_link_->receive();
     }
+  }
+
+  void Navien::update() {
+    ESP_LOGV(TAG, "Conn Status: received: %d, updated: %d", this->received_cnt, this->updated_cnt);
 
     // here we track how many packets were received
     // since the last update

--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -209,6 +209,7 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
   }
 
   void Navien::on_error(){
+    ESP_LOGW(TAG, "Communications interrupted, resetting states!");
     this->target_temp_sensor->publish_state(0);
     this->outlet_temp_sensor->publish_state(0);
     this->inlet_temp_sensor->publish_state(0);
@@ -344,7 +345,7 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
   }
 
   void Navien::loop() {
-    if (navien_link_) {
+    if (navien_link_ && src_ == 0) {
       navien_link_->receive();
     }
   }

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -273,6 +273,7 @@ namespace navien {
 
     virtual float get_setup_priority() const { return setup_priority::HARDWARE; }
     virtual void setup() override;
+    void loop() override;
     void update() override;
     void dump_config() override;
 


### PR DESCRIPTION
This PR attempts to address communications issues I saw while working on #37. Claude.ai helped me diagnose and fix this.

Previously, with the removal of NavienLinkEsp, the receive() call was moved to update() which only runs once per polling interval (typically once/sec).

This caused critical communication issues:
1. Checksum errors: UART bytes accumulated between polls, causing the parser to read across packet boundaries and misalign headers/bodies: ``` [08:56:33.193][E][navien.link:101]: SRC:0x50 Status Packet checksum error: 0x45 (calc) != 0x01 (recv), seed=0x4B
    [08:56:33.193][I][navien.link:305]:    F7 05 50 50 90 22 06 3F 00 EC 01 00 00 00 00 06 00 F7 00 4E 00 00 01 C9 00 00 00 00 00 00 00 F7
    [08:56:33.203][I][navien.link:311]:    05 50 0F 90 2A 45 00 0B 01
    [08:56:38.458][E][navien.link:101]: SRC:0x50 Status Packet checksum error: 0xA0 (calc) != 0x50 (recv), seed=0x4B
    [08:56:38.458][I][navien.link:305]:    F7 05 50 0F 90 2A 45 00 0B 01 0C 04 17 00 62 60 0E 00 00 00 36 1F E0 03 7F 00 00 00 01 13 02 E0
    [08:56:38.525][I][navien.link:311]:    FA 00 72 00 00 00 00 00 82 F2 C0 1C FE F7 05 50 50
    [08:56:43.740][E][navien.link:101]: SRC:0x50 Status Packet checksum error: 0x21 (calc) != 0x0F (recv), seed=0x4B
    [08:56:43.742][I][navien.link:305]:    F7 05 50 50 90 22 42 00 20 25 33 62 60 17 00 00 00 38 37 00 A0 BE 00 20 02 00 00 01 49 01 CD 00
    [08:56:43.748][I][navien.link:311]:    00 F0 80 00 99 F7 05 50 0F
    [08:56:43.819][E][navien.link:101]: SRC:0x50 Status Packet checksum error: 0x33 (calc) != 0x60 (recv), seed=0x4B
    ```
2. Unreliable command sending: The send window was missed because receive() was no longer running continuously. Because of this, commands sent to the Navien were not taking effect, due to bus collisions when they were sent.

Restored the original NavienLinkEsp behavior by adding loop() to the Navien class, which calls receive() on every iteration. This ensures:
- Immediate UART byte processing
- Precise packet boundary tracking
- Timely command sending during RS-485 bus idle gaps

3. Fix where `on_error` is called: previously it was called anytime there was no command pending to be sent. Now it's only called when there's an issue receiving data or parsing a packet.

Checksum errors and communication reliability should now be resolved, matching the behavior of the scheduled_recirc_fixes branch.
