### PR TITLE
Handle configuration without all sensors defined in on_error

### DIFF
--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -212,15 +212,64 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
 
   void Navien::on_error(){
     ESP_LOGW(TAG, "Communications interrupted, resetting states!");
-    this->dhw_set_temp_sensor->publish_state(0);
-    this->outlet_temp_sensor->publish_state(0);
-    this->inlet_temp_sensor->publish_state(0);
-    this->water_flow_sensor->publish_state(0);
+
+    sensor::Sensor *sensors[] = {
+      this->dhw_set_temp_sensor,
+      this->outlet_temp_sensor,
+      this->inlet_temp_sensor,
+      this->gas_dhw_set_temp_sensor,
+      this->gas_outlet_temp_sensor,
+      this->gas_inlet_temp_sensor,
+      this->water_flow_sensor,
+      this->water_utilization_sensor,
+      this->gas_total_sensor,
+      this->gas_current_sensor,
+      this->sh_set_temp_sensor,
+      this->sh_outlet_temp_sensor,
+      this->sh_return_temp_sensor,
+      this->heat_capacity_sensor,
+      this->total_dhw_usage_sensor,
+      this->total_operating_time_sensor,
+      this->cumulative_dwh_usage_hours_sensor,
+      this->cumulative_sh_usage_hours_sensor,
+      this->cumulative_domestic_usage_cnt_sensor,
+      this->days_since_install_sensor
+    };
+
+    for (sensor::Sensor *s : sensors) {
+        if (s != nullptr){
+            s->publish_state(NAN);
+        }
+    }
+
+    text_sensor::TextSensor *text_sensors[] = {
+      this->controller_version_sensor,
+      this->panel_version_sensor,
+      this->heating_mode_sensor,
+      this->device_type_sensor,
+      this->operating_state_sensor,
+      this->recirc_mode_sensor
+    };
+
+    for (text_sensor::TextSensor *t : text_sensors) {
+        if (t != nullptr){
+            t->publish_state("");
+        }
+    }
     
-    this->sh_set_temp_sensor->publish_state(0);
-    this->sh_outlet_temp_sensor->publish_state(0);
-    this->sh_return_temp_sensor->publish_state(0);
-    this->heat_capacity_sensor->publish_state(0);
+    binary_sensor::BinarySensor *binary_sensors[] = {
+      this->boiler_active_sensor,
+      this->conn_status_sensor,
+      this->recirc_running_sensor,
+      this->other_navilink_installed_sensor
+    };
+
+    for (binary_sensor::BinarySensor *b : binary_sensors) {
+        if (b != nullptr){
+            b->publish_state(false);
+        }
+    }
+
     this->is_connected = false;
   }
 


### PR DESCRIPTION
Noticed while working on #44, where segfault could occur in on_error if sensors that were being reset weren't defined.