### PR TITLE
Add Water Heater component implementation

### DIFF
--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -318,6 +318,15 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
     }
 #endif
 
+#ifdef USE_WATER_HEATER
+    if (this->water_heater != nullptr){
+      this->water_heater->set_current_temperature(this->state.water.outlet_temp);
+      this->water_heater->set_target_temperature_state(this->state.water.dhw_set_temp);
+      this->water_heater->set_on_state(this->state.power == POWER_ON);
+      this->water_heater->publish_state();
+    }
+#endif
+
     if (this->recirc_mode_sensor != nullptr) {
       this->recirc_mode_sensor->publish_state(device_recirc_mode_to_str(this->state.recirculation));
     }

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -4,6 +4,7 @@
 #include <list>
 
 #include "esphome/core/component.h"
+#include "esphome/components/button/button.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
@@ -15,6 +16,10 @@
 
 #ifdef USE_SWITCH
 #include "esphome/components/switch/switch.h"
+#endif
+
+#ifdef USE_WATER_HEATER
+#include "water_heater/navien_water_heater.h"
 #endif
 
 #include "navien_link.h"
@@ -207,6 +212,10 @@ namespace navien {
     void set_climate(climate::Climate * c){climate = c;}
 #endif
 
+#ifdef USE_WATER_HEATER
+    void set_water_heater(NavienWaterHeater * w){water_heater = w;}
+#endif
+
   protected:
     /**
      * Sensor definitions
@@ -253,6 +262,10 @@ namespace navien {
 
 #ifdef USE_CLIMATE
     climate::Climate *climate = nullptr;
+#endif
+
+#ifdef USE_WATER_HEATER
+    NavienWaterHeater *water_heater = nullptr;
 #endif
 
     NavienLink *navien_link_;

--- a/esphome/components/navien/water_heater/__init__.py
+++ b/esphome/components/navien/water_heater/__init__.py
@@ -1,0 +1,41 @@
+from esphome.const import (
+  CONF_ID,
+  CONF_MIN_TEMPERATURE,
+  CONF_MAX_TEMPERATURE,
+)
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import water_heater
+from esphome.components.navien.sensor import NAVIEN_CONFIG_ID, Navien
+
+DEPENDENCIES = ["water_heater"]
+
+navien_ns = cg.esphome_ns.namespace("navien")
+
+NavienWaterHeater = navien_ns.class_("NavienWaterHeater", water_heater.WaterHeater, cg.Component)
+
+CONFIG_SCHEMA = cv.All(
+    water_heater.water_heater_schema(NavienWaterHeater)
+    .extend({
+        cv.Required(CONF_ID): cv.declare_id(NavienWaterHeater),
+        cv.GenerateID(NAVIEN_CONFIG_ID): cv.use_id(Navien),
+        cv.Optional(CONF_MIN_TEMPERATURE): cv.temperature,
+        cv.Optional(CONF_MAX_TEMPERATURE): cv.temperature,
+    })
+    .extend(cv.COMPONENT_SCHEMA)
+);
+
+async def to_code(config):
+    var = await water_heater.new_water_heater(config)
+
+    if (min_temp := config.get(CONF_MIN_TEMPERATURE)) is not None:
+        cg.add(var.set_min_temperature(min_temp))
+
+    if (max_temp := config.get(CONF_MAX_TEMPERATURE)) is not None:
+        cg.add(var.set_max_temperature(max_temp))
+
+    paren = await cg.get_variable(config[NAVIEN_CONFIG_ID])
+    cg.add(var.set_parent(paren))
+
+    await cg.register_component(var, config)
+

--- a/esphome/components/navien/water_heater/navien_water_heater.cpp
+++ b/esphome/components/navien/water_heater/navien_water_heater.cpp
@@ -1,0 +1,106 @@
+#include "navien_water_heater.h"
+#include "../navien.h"
+
+namespace esphome {
+namespace navien {
+
+using namespace water_heater;
+
+static const char *TAG = "navien.weater_heater";
+
+NavienWaterHeater::NavienWaterHeater() {
+}
+
+void NavienWaterHeater::set_parent(NavienBase * parent_) {
+  this->parent = parent_;
+  this->parent->set_water_heater(this);
+}
+
+void NavienWaterHeater::setup() {
+}
+
+void NavienWaterHeater::dump_config() {
+  ESP_LOGCONFIG(TAG, "NavienWaterHeater:\n"
+                     "  name: %s\n"
+                     "  min_temperature: %.1f\n"
+                     "  max_temperature: %.1f",
+                     this->get_name().c_str(),
+                     this->min_temperature,
+                     this->max_temperature);
+}
+
+WaterHeaterCallInternal NavienWaterHeater::make_call() {
+  return WaterHeaterCallInternal(this);
+}
+
+void NavienWaterHeater::control(const WaterHeaterCall &call) {
+  if (parent == nullptr) {
+    ESP_LOGE(TAG, "No Navien parent set");
+  }
+  
+  bool set_on_to = is_on();
+
+  if (call.get_mode().has_value()) {
+    set_on_to = (*call.get_mode() != WATER_HEATER_MODE_OFF);
+  }
+
+  if (call.get_on().has_value()) {
+    set_on_to = *call.get_on();
+  }
+
+  if (set_on_to != is_on()) {
+    if (set_on_to) {
+      parent->send_turn_on_cmd();
+    } else {
+      parent->send_turn_off_cmd();
+    }
+  }
+
+  if (!std::isnan(call.get_target_temperature())) {
+    parent->send_dhw_set_temp_cmd(call.get_target_temperature());
+  }
+
+  // Away setting not supported
+  //if (call.get_away().has_value()) {
+  //  *call.get_away();
+  //}
+}
+
+void NavienWaterHeater::set_on_state(bool is_on) {
+  this->set_state_flag_(WATER_HEATER_STATE_ON, is_on);
+  if (is_on) {
+    this->set_mode_(WaterHeaterMode::WATER_HEATER_MODE_GAS);
+  } else {
+    this->set_mode_(WaterHeaterMode::WATER_HEATER_MODE_OFF);
+  }
+}
+
+void NavienWaterHeater::set_target_temperature_state(float t) {
+  this->set_target_temperature_(t);
+}
+
+
+WaterHeaterTraits NavienWaterHeater::traits() {
+  WaterHeaterTraits traits;
+  // Do any models have other settings (eco, high performance, etc)?
+  traits.set_supported_modes({
+    WaterHeaterMode::WATER_HEATER_MODE_OFF,
+    WaterHeaterMode::WATER_HEATER_MODE_GAS
+  });
+  traits.add_feature_flags(WATER_HEATER_SUPPORTS_OPERATION_MODE);
+
+  traits.add_feature_flags(WATER_HEATER_SUPPORTS_CURRENT_TEMPERATURE);
+  traits.add_feature_flags(WATER_HEATER_SUPPORTS_TARGET_TEMPERATURE);
+  traits.add_feature_flags(WATER_HEATER_SUPPORTS_ON_OFF);
+  
+  // Do any models have an away mode or are there commands for schedule control?
+  //traits.add_feature_flags(WATER_HEATER_SUPPORTS_AWAY_MODE);
+
+  traits.set_min_temperature(this->min_temperature);
+  traits.set_max_temperature(this->max_temperature);
+
+  return traits;
+}
+
+} // navien
+} // esphome

--- a/esphome/components/navien/water_heater/navien_water_heater.h
+++ b/esphome/components/navien/water_heater/navien_water_heater.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "esphome/components/water_heater/water_heater.h"
+
+namespace esphome {
+namespace navien {
+
+class NavienBase;
+
+
+// WaterHeater implementation for DHW control
+class NavienWaterHeater : public water_heater::WaterHeater, public Component {
+public:
+  NavienWaterHeater();
+  void set_parent(NavienBase * parent_);
+
+  virtual void setup() override;
+  virtual void dump_config() override;
+  virtual water_heater::WaterHeaterCallInternal make_call() override;
+  virtual void control(const water_heater::WaterHeaterCall &call) override;
+
+  void set_min_temperature(float t) { min_temperature = t; }
+  void set_max_temperature(float t) { max_temperature = t; }
+
+  // Most base class setters are protected. Wrap and make public.
+  // esphome side state only, use control() for actual changes.
+  void set_on_state(bool is_on);
+  void set_target_temperature_state(float t);
+
+protected:
+  virtual water_heater::WaterHeaterTraits traits() override;
+
+private:
+  NavienBase * parent = nullptr;
+
+  // Conservative safe defaults, changeable via config
+  float min_temperature = 32.22; // 90F
+  float max_temperature = 48.89; // 120F
+};
+
+} // navien
+} // esphome

--- a/esphome/navien-d1-mini.yml
+++ b/esphome/navien-d1-mini.yml
@@ -10,6 +10,7 @@ substitutions:
 packages:
   navien: !include navien-base.yml
   sensors: !include navien-sensors.yml
+  #water_heater: !include navien-water-heater.yml
 
 logger:
 #  level: VERBOSE #makes uart stream available in esphome logstream

--- a/esphome/navien-esphome-atom-lite-esp32.yml
+++ b/esphome/navien-esphome-atom-lite-esp32.yml
@@ -10,6 +10,7 @@ substitutions:
 packages:
   navien: !include navien-base.yml
   sensors: !include navien-sensors.yml
+  #water_heater: !include navien-water-heater.yml
 
 esp32:
   framework:

--- a/esphome/navien-esphome-atoms3-lite-tail485-esp32.yml
+++ b/esphome/navien-esphome-atoms3-lite-tail485-esp32.yml
@@ -29,6 +29,7 @@ esp32:
 packages:
   navien: !include navien-base.yml
   sensors: !include navien-sensors.yml
+  #water_heater: !include navien-water-heater.yml
 
 logger:
   level: INFO

--- a/esphome/navien-water-heater.yml
+++ b/esphome/navien-water-heater.yml
@@ -1,0 +1,8 @@
+# Available with esphome >= 2026.2.0
+water_heater:
+  - platform: navien
+    id: navien_water_heater
+    name: "${friendly_name} Water Heater${sensor_suffix}"
+    min_temperature: 98F
+    max_temperature: 120F
+


### PR DESCRIPTION
The base water heater has support for additional features not added in this pass, like mode and away settings, as those don't seem to have any direct mappings for Navien models integrated so far.

Initially wanted to make the inclusion of climate or water heater components dynamic, or at least configurable, but doesn't seem to be a great way to do that with existing yaml features. There is support for dynamic packages in esphome 2025.12.0 (esphome/esphome#11605) but bumping min required version just for this didn't seem worth it.

