### PR TITLE
Fix buffer overflow in print_buffer()

### DIFF
--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -557,7 +557,8 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
     char hex_buffer[100];
     hex_buffer[(3 * 32) + 1] = 0;
     for (size_t i = 0; i < length; i++) {
-      snprintf(&hex_buffer[3 * (i % 32)], sizeof(hex_buffer), "%02X ", data[i]);
+      size_t offset = 3 * (i % 32);
+      snprintf(&hex_buffer[offset], sizeof(hex_buffer) - offset, "%02X ", data[i]);
       if (i % 32 == 31) {
         ESP_LOGD(TAG, "   %s", hex_buffer);
       }

--- a/esphome/components/navien/navien_link.cpp
+++ b/esphome/components/navien/navien_link.cpp
@@ -312,7 +312,8 @@ void NavienLink::print_buffer(const uint8_t *data, size_t length) {
    char hex_buffer[100];
    hex_buffer[(3 * 32) + 1] = 0;
    for (size_t i = 0; i < length; i++) {
-     snprintf(&hex_buffer[3 * (i % 32)], sizeof(hex_buffer), "%02X ", data[i]);
+     size_t offset = 3 * (i % 32);
+     snprintf(&hex_buffer[offset], sizeof(hex_buffer) - offset, "%02X ", data[i]);
      if (i % 32 == 31) {
        ESP_LOGI(TAG, "   %s", hex_buffer);
      }


### PR DESCRIPTION
## Summary

`print_buffer()` in both `navien_link.cpp` and `navien.cpp` passes `sizeof(hex_buffer)` as the size limit to `snprintf()`, but writes starting at an offset into the buffer (`&hex_buffer[3 * (i % 32)]`). This means `snprintf()` thinks it has the full 100-byte buffer available, but can actually only safely write `sizeof(hex_buffer) - offset` bytes before overflowing.

The fix passes the remaining capacity (`sizeof(hex_buffer) - offset`) as the size argument.

## Changes

- `navien_link.cpp` `NavienLink::print_buffer()`: use remaining buffer capacity in `snprintf()`
- `navien.cpp` `Navien::print_buffer()`: same fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)