### PR TITLE
Fix compatibility with ESPHome 2026.3.0

### DIFF
--- a/esphome/components/navien/button.py
+++ b/esphome/components/navien/button.py
@@ -22,8 +22,5 @@ CONFIG_SCHEMA = (
 async def to_code(config):
     var = await button.new_button(config)
     await cg.register_component(var, config)
-    if CONF_ICON in config:
-        cg.add(var.set_icon(config[CONF_ICON]))
-
     hub = await cg.get_variable(config[NAVIEN_CONFIG_ID])
     cg.add(var.set_parent(hub))

--- a/esphome/components/navien/climate/navien_climate.cpp
+++ b/esphome/components/navien/climate/navien_climate.cpp
@@ -32,7 +32,7 @@ climate::ClimateTraits NavienClimate::traits(){
   
 void NavienClimate::control(const climate::ClimateCall &call){
   if (call.get_target_temperature().has_value()){
-    esphome::optional<float> f = call.get_target_temperature();
+    std::optional<float> f = call.get_target_temperature();
     float target = *f;
     
     ESP_LOGD(TAG, "Setting target temperature to %f", target);

--- a/esphome/components/navien/climate/navien_climate.cpp
+++ b/esphome/components/navien/climate/navien_climate.cpp
@@ -31,9 +31,9 @@ climate::ClimateTraits NavienClimate::traits(){
 }
   
 void NavienClimate::control(const climate::ClimateCall &call){
-  if (call.get_target_temperature().has_value()){
-    std::optional<float> f = call.get_target_temperature();
-    float target = *f;
+  auto target_temperature = call.get_target_temperature();
+  if (target_temperature.has_value()){
+    float target = *target_temperature;
     
     ESP_LOGD(TAG, "Setting target temperature to %f", target);
     parent->send_dhw_set_temp_cmd(target);

--- a/esphome/components/navien/sensor.py
+++ b/esphome/components/navien/sensor.py
@@ -23,7 +23,6 @@ from esphome.const import (
     CONF_TARGET_TEMPERATURE,
     
     DEVICE_CLASS_CONNECTIVITY,
-    DEVICE_CLASS_GAS,
     DEVICE_CLASS_RUNNING,
     
     ENTITY_CATEGORY_DIAGNOSTIC,
@@ -115,7 +114,6 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_GAS_TOTAL): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CUBIC_METER,
                 accuracy_decimals=2,
-                device_class=DEVICE_CLASS_GAS,
                 state_class=STATE_CLASS_TOTAL_INCREASING,
             ),
             cv.Optional(CONF_GAS_CURRENT): sensor.sensor_schema(

--- a/esphome/components/navien/sensor.py
+++ b/esphome/components/navien/sensor.py
@@ -15,8 +15,7 @@ NavienLink = navien_ns.class_("NavienLink")
 
 from esphome.const import (
     CONF_UART_ID,
-    CONF_ID, UNIT_EMPTY, ICON_EMPTY,
-    CONF_ICON,
+    CONF_ID, UNIT_EMPTY,
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_SENSOR,
@@ -79,32 +78,39 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_DHW_SET_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=2,
+                icon="mdi:coolant-temperature",
             ),
 
             # Left for backwards compatibility in config. Alias for DHW_SET_TEMPERATURE.
             cv.Optional(CONF_TARGET_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=2,
+                icon="mdi:coolant-temperature",
             ),
-            
+
             cv.Optional(CONF_INLET_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=2,
+                icon="mdi:water-thermometer",
             ),
             cv.Optional(CONF_OUTLET_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=2,
+                icon="mdi:water-thermometer-outline",
             ),
             cv.Optional(CONF_WATER_FLOW): sensor.sensor_schema(
                 unit_of_measurement=UNIT_LPM,
                 accuracy_decimals=2,
+                icon="mdi:gauge",
             ),
             cv.Optional(CONF_WATER_UTILIZATION): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=2,
+                icon="mdi:water-percent",
             ),
             cv.Optional(CONF_RECIRC_RUNNING): binary_sensor.binary_sensor_schema(
-                device_class = DEVICE_CLASS_RUNNING
+                device_class=DEVICE_CLASS_RUNNING,
+                icon="mdi:water-sync",
             ),
             cv.Optional(CONF_GAS_TOTAL): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CUBIC_METER,
@@ -115,18 +121,22 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_GAS_CURRENT): sensor.sensor_schema(
                 unit_of_measurement=UNIT_BTU,
                 accuracy_decimals=2,
+                icon="mdi:gas-burner",
             ),
             cv.Optional(CONF_SH_SET_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=2,
+                icon="mdi:coolant-temperature",
             ),
             cv.Optional(CONF_SH_OUTLET_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=2,
+                icon="mdi:thermometer-lines",
             ),
             cv.Optional(CONF_SH_RETURN_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 accuracy_decimals=2,
+                icon="mdi:thermometer-lines",
             ),
             cv.Optional(CONF_OUTDOOR_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
@@ -136,26 +146,32 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_HEAT_CAPACITY): sensor.sensor_schema(
                 unit_of_measurement=UNIT_PERCENT,
                 accuracy_decimals=2,
+                icon="mdi:heat-wave",
             ),
             cv.Optional(CONF_TOTAL_DHW_USAGE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_EMPTY,
                 accuracy_decimals=0,
+                icon="mdi:water-boiler",
             ),
             cv.Optional(CONF_TOTAL_OPERATING_TIME): sensor.sensor_schema(
                 unit_of_measurement=UNIT_HOUR,
                 accuracy_decimals=0,
+                icon="mdi:clock-outline",
             ),
             cv.Optional(CONF_CUMULATIVE_DWH_USAGE_HOURS): sensor.sensor_schema(
                 unit_of_measurement=UNIT_HOUR,
                 accuracy_decimals=0,
+                icon="mdi:clock-outline",
             ),
             cv.Optional(CONF_CUMULATIVE_SH_USAGE_HOURS): sensor.sensor_schema(
                 unit_of_measurement=UNIT_HOUR,
                 accuracy_decimals=0,
+                icon="mdi:clock-outline",
             ),
             cv.Optional(CONF_DAYS_SINCE_INSTALL): sensor.sensor_schema(
                 unit_of_measurement=UNIT_EMPTY,
                 accuracy_decimals=0,
+                icon="mdi:calendar-clock",
             ),
             cv.Optional(CONF_BOILER_ACTIVE): binary_sensor.binary_sensor_schema(),
             
@@ -204,32 +220,26 @@ async def to_code(config):
 
     if dhw_set_temp_config_key:
         sens = await sensor.new_sensor(config[dhw_set_temp_config_key])
-        cg.add(sens.set_icon(config[dhw_set_temp_config_key].get(CONF_ICON, "mdi:coolant-temperature")))
         cg.add(var.set_dhw_set_temp_sensor(sens))
-    
+
     if CONF_INLET_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_INLET_TEMPERATURE])
-        cg.add(sens.set_icon(config[CONF_INLET_TEMPERATURE].get(CONF_ICON, "mdi:water-thermometer")))
         cg.add(var.set_inlet_temp_sensor(sens))
-   
+
     if CONF_OUTLET_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_OUTLET_TEMPERATURE])
-        cg.add(sens.set_icon(config[CONF_OUTLET_TEMPERATURE].get(CONF_ICON, "mdi:water-thermometer-outline")))
         cg.add(var.set_outlet_temp_sensor(sens))
-    
+
     if CONF_WATER_FLOW in config:
         sens = await sensor.new_sensor(config[CONF_WATER_FLOW])
-        cg.add(sens.set_icon(config[CONF_WATER_FLOW].get(CONF_ICON, "mdi:gauge")))
         cg.add(var.set_water_flow_sensor(sens))
 
     if CONF_WATER_UTILIZATION in config:
         sens = await sensor.new_sensor(config[CONF_WATER_UTILIZATION])
-        cg.add(sens.set_icon(config[CONF_WATER_UTILIZATION].get(CONF_ICON, "mdi:water-percent")))
         cg.add(var.set_water_utilization_sensor(sens))
 
     if CONF_RECIRC_RUNNING in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_RECIRC_RUNNING])
-        cg.add(sens.set_icon(config[CONF_RECIRC_RUNNING].get(CONF_ICON, "mdi:water-sync")))
         cg.add(var.set_recirc_running_sensor(sens))
         
     if CONF_GAS_TOTAL in config:
@@ -238,7 +248,6 @@ async def to_code(config):
 
     if CONF_GAS_CURRENT in config:
         sens = await sensor.new_sensor(config[CONF_GAS_CURRENT])
-        cg.add(sens.set_icon(config[CONF_GAS_CURRENT].get(CONF_ICON, "mdi:gas-burner")))
         cg.add(var.set_gas_current_sensor(sens))
         
     if CONF_REAL_TIME in config:
@@ -258,17 +267,14 @@ async def to_code(config):
 
     if CONF_SH_SET_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_SH_SET_TEMPERATURE])
-        cg.add(sens.set_icon(config[CONF_SH_SET_TEMPERATURE].get(CONF_ICON, "mdi:coolant-temperature")))
         cg.add(var.set_sh_set_temp_sensor(sens))
 
     if CONF_SH_OUTLET_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_SH_OUTLET_TEMPERATURE])
-        cg.add(sens.set_icon(config[CONF_SH_OUTLET_TEMPERATURE].get(CONF_ICON, "mdi:thermometer-lines")))
         cg.add(var.set_sh_outlet_temp_sensor(sens))
-        
+
     if CONF_SH_RETURN_TEMPERATURE in config:
         sens = await sensor.new_sensor(config[CONF_SH_RETURN_TEMPERATURE])
-        cg.add(sens.set_icon(config[CONF_SH_RETURN_TEMPERATURE].get(CONF_ICON, "mdi:thermometer-lines")))
         cg.add(var.set_sh_return_temp_sensor(sens))
 
     if CONF_OUTDOOR_TEMPERATURE in config:
@@ -277,32 +283,26 @@ async def to_code(config):
         
     if CONF_HEAT_CAPACITY in config:
         sens = await sensor.new_sensor(config[CONF_HEAT_CAPACITY])
-        cg.add(sens.set_icon(config[CONF_HEAT_CAPACITY].get(CONF_ICON, "mdi:heat-wave")))
         cg.add(var.set_heat_capacity_sensor(sens))
-        
+
     if CONF_TOTAL_DHW_USAGE in config:
         sens = await sensor.new_sensor(config[CONF_TOTAL_DHW_USAGE])
-        cg.add(sens.set_icon(config[CONF_TOTAL_DHW_USAGE].get(CONF_ICON, "mdi:water-boiler")))
         cg.add(var.set_total_dhw_usage_sensor(sens))
-        
+
     if CONF_TOTAL_OPERATING_TIME in config:
         sens = await sensor.new_sensor(config[CONF_TOTAL_OPERATING_TIME])
-        cg.add(sens.set_icon(config[CONF_TOTAL_OPERATING_TIME].get(CONF_ICON, "mdi:clock-outline")))
-        cg.add(var.set_total_operating_time_sensor(sens))  
-        
+        cg.add(var.set_total_operating_time_sensor(sens))
+
     if CONF_CUMULATIVE_DWH_USAGE_HOURS in config:
         sens = await sensor.new_sensor(config[CONF_CUMULATIVE_DWH_USAGE_HOURS])
-        cg.add(sens.set_icon(config[CONF_CUMULATIVE_DWH_USAGE_HOURS].get(CONF_ICON, "mdi:clock-outline")))
-        cg.add(var.set_cumulative_dwh_usage_hours_sensor(sens))  
-        
+        cg.add(var.set_cumulative_dwh_usage_hours_sensor(sens))
+
     if CONF_CUMULATIVE_SH_USAGE_HOURS in config:
         sens = await sensor.new_sensor(config[CONF_CUMULATIVE_SH_USAGE_HOURS])
-        cg.add(sens.set_icon(config[CONF_CUMULATIVE_SH_USAGE_HOURS].get(CONF_ICON, "mdi:clock-outline")))
-        cg.add(var.set_cumulative_sh_usage_hours_sensor(sens))  
-        
+        cg.add(var.set_cumulative_sh_usage_hours_sensor(sens))
+
     if CONF_DAYS_SINCE_INSTALL in config:
         sens = await sensor.new_sensor(config[CONF_DAYS_SINCE_INSTALL])
-        cg.add(sens.set_icon(config[CONF_DAYS_SINCE_INSTALL].get(CONF_ICON, "mdi:calendar-clock")))
         cg.add(var.set_days_since_install_sensor(sens))
  
     if CONF_OTHER_NAVILINK_INSTALLED in config:

--- a/esphome/components/navien/switch.py
+++ b/esphome/components/navien/switch.py
@@ -43,9 +43,6 @@ async def to_code(config):
     var = await switch.new_switch(config)
     await cg.register_component(var, config)
 
-    if CONF_ICON in config:
-        cg.add(var.set_icon(config[CONF_ICON]))
-    
     paren = await cg.get_variable(config[NAVIEN_CONFIG_ID])
     cg.add(var.set_parent(paren))
     

--- a/esphome/components/navien/text_sensor.py
+++ b/esphome/components/navien/text_sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import text_sensor
+from esphome.const import CONF_ICON
 from esphome.components.navien.sensor import NAVIEN_CONFIG_ID, Navien
 
 AUTO_LOAD = ["text_sensor", "sensor"]
@@ -11,23 +12,42 @@ CONF_OPERATING_STATE = "operating_state"
 CONF_PANEL_VERSION = "panel_version"
 CONF_CONTROLLER_VERSION = "controller_version"
 
-CONFIG_SCHEMA = (
+_DEFAULT_ICONS = {
+    CONF_HEATING_MODE: "mdi:autorenew",
+    CONF_DEVICE_TYPE: "mdi:chip",
+    CONF_OPERATING_STATE: "mdi:information-outline",
+    CONF_PANEL_VERSION: "mdi:monitor-dashboard",
+    CONF_CONTROLLER_VERSION: "mdi:chip",
+}
+
+def _set_default_icon(config):
+    if CONF_ICON in config:
+        return config
+    for key, icon in _DEFAULT_ICONS.items():
+        if config.get(key, False):
+            config = config.copy()
+            config[CONF_ICON] = icon
+            return config
+    return config
+
+CONFIG_SCHEMA = cv.All(
     text_sensor.text_sensor_schema()
     .extend(
         {
             cv.GenerateID(NAVIEN_CONFIG_ID): cv.use_id(Navien),
-            
+
             cv.Optional(CONF_HEATING_MODE): cv.boolean,
-            
+
             cv.Optional(CONF_DEVICE_TYPE): cv.boolean,
-            
+
             cv.Optional(CONF_OPERATING_STATE): cv.boolean,
-            
+
             cv.Optional(CONF_PANEL_VERSION): cv.boolean,
-            
+
             cv.Optional(CONF_CONTROLLER_VERSION): cv.boolean,
         }
-    )
+    ),
+    _set_default_icon,
 )
 
 async def to_code(config):
@@ -35,21 +55,16 @@ async def to_code(config):
     paren = await cg.get_variable(config[NAVIEN_CONFIG_ID])
     
     if config.get(CONF_HEATING_MODE, False):
-        cg.add(var.set_icon("mdi:autorenew"))
         cg.add(paren.set_heating_mode_sensor(var))
-        
+
     if config.get(CONF_DEVICE_TYPE, False):
-        cg.add(var.set_icon("mdi:chip"))
         cg.add(paren.set_device_type_sensor(var))
-        
+
     if config.get(CONF_OPERATING_STATE, False):
-        cg.add(var.set_icon("mdi:information-outline"))
         cg.add(paren.set_operating_state_sensor(var))
-        
+
     if config.get(CONF_PANEL_VERSION, False):
-        cg.add(var.set_icon("mdi:monitor-dashboard"))
         cg.add(paren.set_panel_version_sensor(var))
-        
+
     if config.get(CONF_CONTROLLER_VERSION, False):
-        cg.add(var.set_icon("mdi:chip"))
         cg.add(paren.set_controller_version_sensor(var))


### PR DESCRIPTION
ESPHome 2026.3.0 packed EntityBase setters (`set_icon`, `set_device_class`, etc.) into `configure_entity_()`, which is driven by the config dict rather than individual codegen calls (#14564). It also replaced `esphome::optional` with `std::optional` for C++17 compliance.

Move sensor and binary_sensor icons into schema parameters so they flow through `configure_entity_()` automatically. For text_sensor, inject the default icon via a config validator (the shared schema makes per-type defaults impractical otherwise).

(I've deployed this on my sensor and it seems to work fine.)