### PR TITLE
Fix cascade status routing by source address

### DIFF
--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -84,6 +84,10 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
   }
 
   void Navien::on_water(const WATER_DATA & water, uint8_t src){
+    if (src != PACKET_SRC_STATUS + this->src_) {
+      return;
+    }
+
     ESP_LOGD(TAG, "SRC:0x%02X Received Temp: 0x%02X, Inlet: 0x%02X, Outlet: 0x%02X, Flow: 0x%02X, Sys Power: 0x%02X, Sys Status: 0x%02X, Recirc Enabled: 0x%02X",
              src,
              water.dhw_set_temp,
@@ -148,6 +152,10 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
   }
 
   void Navien::on_gas(const GAS_DATA & gas, uint8_t src){
+    if (src != PACKET_SRC_STATUS + this->src_) {
+      return;
+    }
+
     ESP_LOGD(TAG, "SRC:0x%02X Received Gas DHW Temp: 0x%02X, Inlet: 0x%02X, Outlet: 0x%02X, SH Temp: 0x%02X",
        src,
        gas.dhw_set_temp,

--- a/esphome/components/navien/navien_link.cpp
+++ b/esphome/components/navien/navien_link.cpp
@@ -10,7 +10,6 @@ namespace navien {
 
 static const char *TAG = "navien.link";
 
-
 NavienLink *NavienLink::get_instance(NavienUartI *uart) {
   static NavienLink *instance = nullptr;
   if (instance == nullptr) {
@@ -64,19 +63,13 @@ void NavienLink::parse_status_packet(){
              this->recv_buffer.water.unknown_06,
              this->recv_buffer.water.unknown_32,
              this->recv_buffer.water.recirculation_enabled);
-    for (uint8_t i = 0; i < NAVIEN_CASCADE_MAX; ++i) {
-      if (visitors_[i]) {
-        visitors_[i]->on_water(recv_buffer.water, recv_buffer.hdr.src);
-      }
-    }
+    for (uint8_t i = 0; i < NAVIEN_CASCADE_MAX; ++i)
+      if (visitors_[i]) visitors_[i]->on_water(recv_buffer.water, recv_buffer.hdr.src);
     break;
   case PACKET_DST_GAS:
-    ESP_LOGD(TAG, "SRC:0x%02X => Gas", this->recv_buffer.hdr.src); 
-    for (uint8_t i = 0; i < NAVIEN_CASCADE_MAX; ++i) {
-      if (visitors_[i]) {
-        visitors_[i]->on_gas(recv_buffer.gas, recv_buffer.hdr.src);
-      }
-    }
+    ESP_LOGD(TAG, "SRC:0x%02X => Gas", this->recv_buffer.hdr.src);
+    for (uint8_t i = 0; i < NAVIEN_CASCADE_MAX; ++i)
+      if (visitors_[i]) visitors_[i]->on_gas(recv_buffer.gas, recv_buffer.hdr.src);
     break;
   }
 }


### PR DESCRIPTION
In cascade setups, status packets from different units were being broadcast to every registered visitor. That allowed one unit’s water/gas state to overwrite another’s, including recirculation-related state.

This change routes status packets by source address so each configured unit only consumes its own water/gas status packets.

Why this matters:
- prevents cross-talk between cascade members
- fixes state contamination between `src:0`, `src:1`, etc.
- resolves recirculation state toggling caused by mixed packet streams

I reproduced this on a two-unit cascade system and verified the fix by comparing debug packet sources and panel readings against Home Assistant state.
