### PR TITLE
Do not force Allow Recirculation state during setup

### DIFF
--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -607,15 +607,6 @@ void NavienOnOffSwitch::dump_config(){
 
 void NavienAllowScheduledRecircSwitch::setup() {
   ESP_LOGCONFIG(TAG, "Setting up Allow Recirculation Switch '%s'...", this->name_.c_str());
-
-  bool initial_state = false;
-
-  // write state before setup
-  if (initial_state) {
-    this->turn_on();
-  } else {
-    this->turn_off();
-  }
 }
 
 void NavienAllowScheduledRecircSwitch::write_state(bool state) {


### PR DESCRIPTION
`NavienAllowScheduledRecircSwitch::setup()` was forcing an initial switch write during startup, defaulting the entity to `off`.

That can override the heater's real recirculation state during boot and lead to inconsistent startup behavior.

This change makes setup passive by removing the forced initial on/off write.
