### PR TITLE
Add decoding and sensors for error code and level

### DIFF
--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -88,7 +88,8 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
       return;
     }
 
-    ESP_LOGD(TAG, "SRC:0x%02X Received Temp: 0x%02X, Inlet: 0x%02X, Outlet: 0x%02X, Flow: 0x%02X, Sys Power: 0x%02X, Sys Status: 0x%02X, Recirc Enabled: 0x%02X",
+    ESP_LOGD(TAG, "SRC:0x%02X Received Temp: 0x%02X, Inlet: 0x%02X, Outlet: 0x%02X, Flow: 0x%02X, Sys Power: 0x%02X, Sys Status: 0x%02X, Recirc Enabled: 0x%02X, "
+                  "Err Code:0x%02X 0x%02X, Err Lvl:0x%02X",
              src,
              water.dhw_set_temp,
              water.inlet_temp,
@@ -96,7 +97,10 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
              water.water_flow,
              water.system_power,
              water.system_status,
-             water.recirculation_enabled);
+             water.recirculation_enabled,
+             water.error_code_hi,
+             water.error_code_lo,
+             water.error_level);
 
     if (water.system_power & POWER_STATUS_ON_OFF_MASK){
       state.power = POWER_ON;
@@ -146,6 +150,9 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
             (water.recirculation_enabled & RECIRC_STATUS_FLAG_HOTBUTTON_ON);
     }
     this->state.water.scheduled_recirc_allowed = water.recirculation_enabled & RECIRC_STATUS_FLAG_SCHEDULED_ON;
+
+    this->state.water.error_code = water.error_code_hi << 8 | water.error_code_lo;
+    this->state.water.error_level = water.error_level;
 
     if (this->is_rt)
       this->update_water_sensors();
@@ -243,7 +250,9 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
       this->cumulative_dwh_usage_hours_sensor,
       this->cumulative_sh_usage_hours_sensor,
       this->cumulative_domestic_usage_cnt_sensor,
-      this->days_since_install_sensor
+      this->days_since_install_sensor,
+      this->error_code_sensor,
+      this->error_level_sensor
     };
 
     for (sensor::Sensor *s : sensors) {
@@ -347,6 +356,12 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
     if (this->operating_state_sensor != nullptr){
       std::string operating_state_str = op_state_to_str(this->state.operating_state);
       this->operating_state_sensor->publish_state(operating_state_str);
+    }
+    if (this->error_code_sensor != nullptr){
+        this->error_code_sensor->publish_state(this->state.water.error_code);
+    }
+    if (this->error_level_sensor != nullptr){
+        this->error_level_sensor->publish_state(this->state.water.error_level);
     }
   }
 

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -102,6 +102,8 @@ namespace navien {
       bool boiler_active;
       bool scheduled_recirc_allowed;
       bool recirc_running;
+      uint16_t error_code;
+      uint8_t error_level;
     } water;
     struct{
       float  dhw_set_temp;
@@ -188,6 +190,8 @@ namespace navien {
     void set_cumulative_sh_usage_hours_sensor(sensor::Sensor *sensor) { cumulative_sh_usage_hours_sensor = sensor; }
     void set_cumulative_domestic_usage_cnt_sensor(sensor::Sensor *sensor) { cumulative_domestic_usage_cnt_sensor = sensor; }
     void set_other_navilink_installed_sensor(binary_sensor::BinarySensor *sensor) { other_navilink_installed_sensor = sensor; }
+    void set_error_code_sensor(sensor::Sensor * sensor) { error_code_sensor = sensor; }
+    void set_error_level_sensor(sensor::Sensor *sensor) { error_level_sensor = sensor; }
 
 #ifdef USE_SWITCH
     /**
@@ -233,6 +237,8 @@ namespace navien {
     sensor::Sensor *cumulative_sh_usage_hours_sensor = nullptr;
     sensor::Sensor *cumulative_domestic_usage_cnt_sensor = nullptr;
     sensor::Sensor *days_since_install_sensor = nullptr;
+    sensor::Sensor *error_code_sensor = nullptr;
+    sensor::Sensor *error_level_sensor = nullptr;
 
     text_sensor::TextSensor *controller_version_sensor = nullptr;
     text_sensor::TextSensor *panel_version_sensor = nullptr;

--- a/esphome/components/navien/navien_proto.h
+++ b/esphome/components/navien/navien_proto.h
@@ -190,9 +190,9 @@ typedef struct {
   uint8_t dhw_set_temp;
   uint8_t outlet_temp;
   uint8_t inlet_temp;
-  uint8_t unknown_14; //0x00 on NCB-H
-  uint8_t unknown_15; //0x00 on NCB-H
-  uint8_t unknown_16; //0x00 on NCB-H
+  uint8_t error_code_lo;
+  uint8_t error_code_hi;
+  uint8_t error_level; // Possibly more info in high bits?
   uint8_t operating_capacity;
   uint8_t water_flow;
   uint8_t unknown_19; //0x00 on NCB-H

--- a/esphome/components/navien/sensor.py
+++ b/esphome/components/navien/sensor.py
@@ -67,6 +67,8 @@ CONF_CUMULATIVE_SH_USAGE_HOURS  = "total_sh_usage_hours"
 CONF_DAYS_SINCE_INSTALL         = "days_since_install"
 CONF_SRC                        = "src"
 CONF_OTHER_NAVILINK_INSTALLED   = "other_navilink_installed"
+CONF_ERROR_CODE                 = "error_code"
+CONF_ERROR_LEVEL                = "error_level"
 
 
 CONFIG_SCHEMA = cv.All(
@@ -165,6 +167,16 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_OTHER_NAVILINK_INSTALLED): binary_sensor.binary_sensor_schema(
                 device_class = DEVICE_CLASS_CONNECTIVITY,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC
+            ),
+            cv.Optional(CONF_ERROR_CODE): sensor.sensor_schema(
+                accuracy_decimals=0,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                icon="mdi:alert-circle",
+            ),
+            cv.Optional(CONF_ERROR_LEVEL): sensor.sensor_schema(
+                accuracy_decimals=0,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+                icon="mdi:alert-circle",
             ),
             cv.Optional(CONF_REAL_TIME): cv.boolean,
             cv.Optional(CONF_SRC): cv.int_range(min=0, max=15)
@@ -307,3 +319,11 @@ async def to_code(config):
     if CONF_OTHER_NAVILINK_INSTALLED in config:
         sens = await binary_sensor.new_binary_sensor(config[CONF_OTHER_NAVILINK_INSTALLED])
         cg.add(var.set_other_navilink_installed_sensor(sens))
+
+    if CONF_ERROR_CODE in config:
+        sens = await sensor.new_sensor(config[CONF_ERROR_CODE])
+        cg.add(var.set_error_code_sensor(sens))
+
+    if CONF_ERROR_LEVEL in config:
+        sens = await sensor.new_sensor(config[CONF_ERROR_LEVEL])
+        cg.add(var.set_error_level_sensor(sens))

--- a/esphome/navien-sensors.yml
+++ b/esphome/navien-sensors.yml
@@ -133,6 +133,12 @@ sensor:
     other_navilink_installed:
       id: other_navilink_installed
       name: "${friendly_name} Other NaviLink Installed${sensor_suffix}"
+    error_code:
+      id: error_code
+      name: "${friendly_name} Error Code${sensor_suffix}"
+    error_level:
+      id: error_level
+      name: "${friendly_name} Error Level${sensor_suffix}"
 
   # HA-compatible gas sensors. These are disabled by default; enable them in
   # the ESPHome integration if you want Energy Dashboard compatibility.


### PR DESCRIPTION
Example error state on unit:
![navien-error](https://github.com/user-attachments/assets/99295344-39f1-4718-a44f-427676334289)

Associated sensor from this change:
<img width="350" height="358" alt="error-sensors" src="https://github.com/user-attachments/assets/ab8a20a1-de19-415f-a438-662c1f17ac3a" />

And snippet from service manual for this unit (NFC) and code:
<img width="911" height="174" alt="error-manual" src="https://github.com/user-attachments/assets/e5857b83-6dad-44ec-8894-015ed3f3b805" />

Fixes #57 