### PR TITLE
refactor(esphome): extract wifi transport into separate package

### DIFF
--- a/esphome/navien-base.yml
+++ b/esphome/navien-base.yml
@@ -26,22 +26,6 @@ ${platform}:
 external_components:
   - source: ${external_component_source}
 
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-    
-  # Enable fallback hotspot (captive portal) in case wifi connection fails
-  ap:
-    ssid: !secret ap_ssid
-    password: !secret ap_password
-
-captive_portal:
-  id: navien_portal
-
-web_server:
-  port: 80
-  # https://esphome.io/components/web_server.html
-
 api:
 
 ota:
@@ -71,13 +55,6 @@ text_sensor:
     name: "${friendly_name} ESPHome Version"
     id: esphome_version
     hide_timestamp: True
-  - platform: wifi_info
-    ip_address:
-      id: ip_address
-      name: "${friendly_name} IP Address"
-    mac_address:
-      name: "${friendly_name} Mac"
-      id: mac_address
 
 
 

--- a/esphome/navien-d1-mini.yml
+++ b/esphome/navien-d1-mini.yml
@@ -9,6 +9,7 @@ substitutions:
 
 packages:
   navien: !include navien-base.yml
+  transport: !include navien-transport-wifi.yml
   sensors: !include navien-sensors.yml
   #water_heater: !include navien-water-heater.yml
 

--- a/esphome/navien-esphome-atom-lite-esp32.yml
+++ b/esphome/navien-esphome-atom-lite-esp32.yml
@@ -9,6 +9,7 @@ substitutions:
 
 packages:
   navien: !include navien-base.yml
+  transport: !include navien-transport-wifi.yml
   sensors: !include navien-sensors.yml
   #water_heater: !include navien-water-heater.yml
 

--- a/esphome/navien-esphome-atoms3-lite-tail485-esp32.yml
+++ b/esphome/navien-esphome-atoms3-lite-tail485-esp32.yml
@@ -28,6 +28,7 @@ esp32:
     
 packages:
   navien: !include navien-base.yml
+  transport: !include navien-transport-wifi.yml
   sensors: !include navien-sensors.yml
   #water_heater: !include navien-water-heater.yml
 

--- a/esphome/navien-transport-wifi.yml
+++ b/esphome/navien-transport-wifi.yml
@@ -1,0 +1,24 @@
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  # Enable fallback hotspot (captive portal) in case wifi connection fails
+  ap:
+    ssid: !secret ap_ssid
+    password: !secret ap_password
+
+captive_portal:
+  id: navien_portal
+
+web_server:
+  port: 80
+  # https://esphome.io/components/web_server.html
+
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      id: ip_address
+      name: "${friendly_name} IP Address"
+    mac_address:
+      name: "${friendly_name} Mac"
+      id: mac_address


### PR DESCRIPTION
## What

Extracts the wifi-based network transport out of `navien-base.yml` into its own package file (`navien-transport-wifi.yml`).

## Why

`navien-base.yml` currently hardcodes `wifi:`, `captive_portal:`, `web_server:`, and `wifi_info` text sensors. This prevents boards that can't use wifi — specifically ESP32-C6 running OpenThread, whose single radio can't run both stacks — from reusing the rest of the base config.

Separating transport from the rest of the base is a prerequisite for adding an OpenThread-based board config, which I'd like to submit as a follow-up PR.

## What changes for existing users

Nothing. All existing board YAMLs (`navien-d1-mini.yml`, `navien-esphome-atom-lite-esp32.yml`, `navien-esphome-atoms3-lite-tail485-esp32.yml`) now include `navien-transport-wifi.yml` alongside `navien-base.yml`, so they merge to byte-identical final configs.

Boards that include another board YAML transitively (`navien-wrd-hb.yml` → d1-mini, `navien-ht-device.yml` → wrd-hb) are unchanged — they pick up the transport package through the include chain. Notably, the `id(navien_portal).is_active()` lambda in `navien-ht-device.yml` still resolves because the captive_portal id remains in scope via the transitive include.

## Follow-up

A second PR will add ESP32-C6 + OpenThread support using a `navien-transport-thread.yml` sibling package. Keeping that separate so this PR stays pure refactor.

#52 