### PR TITLE
Handle cascade sub-unit data frames from the master

### DIFF
--- a/esphome/components/navien/navien.cpp
+++ b/esphome/components/navien/navien.cpp
@@ -102,6 +102,31 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
              water.error_code_lo,
              water.error_level);
 
+    this->apply_water_data_(water, static_cast<OPERATING_STATE>(water.operating_state), water.boiler_active & 0x01);
+  }
+
+  void Navien::on_cascade_water(const WATER_DATA & water, uint8_t dst){
+    if (dst != PACKET_SRC_STATUS + this->src_) {
+      return;
+    }
+
+    ESP_LOGD(TAG, "Cascade DST:0x%02X Received Temp: 0x%02X, Inlet: 0x%02X, Outlet: 0x%02X, Flow: 0x%02X, Sys Power: 0x%02X, Sys Status: 0x%02X, Recirc Enabled: 0x%02X",
+             dst,
+             water.dhw_set_temp,
+             water.inlet_temp,
+             water.outlet_temp,
+             water.water_flow,
+             water.system_power,
+             water.system_status,
+             water.recirculation_enabled);
+
+    bool boiler_active =
+        (water.heating_mode != HEATING_MODE_IDLE) || water.water_flow > 0 || water.operating_capacity > 0;
+    OPERATING_STATE operating_state = boiler_active ? ACTIVE_COMBUSTION : STANDBY;
+    this->apply_water_data_(water, operating_state, boiler_active);
+  }
+
+  void Navien::apply_water_data_(const WATER_DATA & water, OPERATING_STATE operating_state, bool boiler_active){
     if (water.system_power & POWER_STATUS_ON_OFF_MASK){
       state.power = POWER_ON;
     }else{
@@ -123,14 +148,13 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
     }else{
       state.recirculation = RECIRC_OFF;
     }
-    
-    state.heating_mode = static_cast<DEVICE_HEATING_MODE>(water.heating_mode);
 
-    state.operating_state = static_cast<OPERATING_STATE>(water.operating_state);
+    state.heating_mode = static_cast<DEVICE_HEATING_MODE>(water.heating_mode);
+    state.operating_state = operating_state;
     // Update the counter that will be used in assessment
     // of whether we're connected to navien or not
     this->received_cnt++;
-    this->state.water.boiler_active = water.boiler_active & 0x01;
+    this->state.water.boiler_active = boiler_active;
     this->state.water.dhw_set_temp = NavienLink::t2c(water.dhw_set_temp);
     this->state.water.outlet_temp = NavienLink::t2c(water.outlet_temp);
     this->state.water.inlet_temp = NavienLink::t2c(water.inlet_temp);
@@ -150,7 +174,6 @@ void NavienBase::send_scheduled_recirculation_off_cmd() {
             (water.recirculation_enabled & RECIRC_STATUS_FLAG_HOTBUTTON_ON);
     }
     this->state.water.scheduled_recirc_allowed = water.recirculation_enabled & RECIRC_STATUS_FLAG_SCHEDULED_ON;
-
     this->state.water.error_code = water.error_code_hi << 8 | water.error_code_lo;
     this->state.water.error_level = water.error_level;
 

--- a/esphome/components/navien/navien.h
+++ b/esphome/components/navien/navien.h
@@ -337,8 +337,10 @@ namespace navien {
      * NavienLinkVisitorI interface implementation
      */
     virtual void on_water(const WATER_DATA & water, uint8_t src);
+    virtual void on_cascade_water(const WATER_DATA & water, uint8_t dst) override;
     virtual void on_gas(const GAS_DATA & gas, uint8_t src);
     virtual void on_error();
+    void apply_water_data_(const WATER_DATA & water, OPERATING_STATE operating_state, bool boiler_active);
 
   protected:
   /**

--- a/esphome/components/navien/navien_link.cpp
+++ b/esphome/components/navien/navien_link.cpp
@@ -105,6 +105,17 @@ void NavienLink::parse_packet(){
    * we're yet to discover. For now we simply ignore those packets. 
    */
     if (this->recv_buffer.hdr.src != PACKET_SRC_CONTROL) {
+      if (this->recv_buffer.hdr.src == PACKET_SRC_STATUS && this->recv_buffer.hdr.len == 34 &&
+          this->recv_buffer.hdr.dst > PACKET_DST_WATER &&
+          this->recv_buffer.hdr.dst < PACKET_DST_WATER + NAVIEN_CASCADE_MAX) {
+        ESP_LOGD(TAG, "Cascade sub water packet src:0x%02X dst:0x%02X len:%u",
+                 this->recv_buffer.hdr.src,
+                 this->recv_buffer.hdr.dst,
+                 this->recv_buffer.hdr.len);
+        for (uint8_t i = 0; i < NAVIEN_CASCADE_MAX; ++i)
+          if (visitors_[i]) visitors_[i]->on_cascade_water(recv_buffer.water, recv_buffer.hdr.dst);
+        return;
+      }
       ESP_LOGD(TAG, "Control packet from SRC:0x%02X - we don't know how to handle it yet", this->recv_buffer.hdr.src);
       return;
     }

--- a/esphome/components/navien/navien_link.h
+++ b/esphome/components/navien/navien_link.h
@@ -72,6 +72,7 @@ public:
    * @param src - the source address from the packet header
    */  
   virtual void on_water(const WATER_DATA & water, uint8_t src) = 0;
+  virtual void on_cascade_water(const WATER_DATA & water, uint8_t dst) { this->on_water(water, dst); }
 
   /**
    * Called then the direction is from Navien to reporting device


### PR DESCRIPTION
Fixes #64.

In some cascade configurations, sub-unit telemetry is reported in full-length cascade frames from the master instead of only through the normal status packet path. These frames look like:

dir:0x10 src:0x50 dst:0x51 len:34

The packet contains valid sub-unit data, with the sub unit identified by the destination address. The previous parser treated these frames as unknown control packets and discarded them, which caused sub-unit entities to stop updating or become unavailable.

This change recognizes those full-length cascade status/data frames before they are discarded and routes them through a cascade-specific visitor callback. The Navien instance then filters the packet by destination address so the data is applied only to the configured sub unit.

## Changes

- Detect full-length cascade sub-unit data frames in `navien_link.cpp`
- Add `on_cascade_water(...)` to the visitor interface
- Add `Navien::on_cascade_water(...)` to publish cascade sub-unit data by destination address
- Keep configured unit filtering in the visitor layer, matching the existing source-filtering pattern

## Testing

Tested on a two-unit cascade setup where the sub unit had changed allocation from `S1` to `S2` after a system power cycle.

With this change, sub-unit entities updated correctly while the unit was shown as `S2`, including:

- Temperatures
- Operating state
- Error code/error level
- Flow
- Capacity/utilization
- Recirculation state

After switching the sub unit back to `S1`, the same entities continued to update correctly.

Most cascade users are likely still allocated as `S1`, so additional validation from other cascade systems would be helpful to confirm the common case continues to work as expected. I do not expect others to modify their cascade setup to test this; I would mainly like confirmation that this does not break systems that are currently working.

## Notes

Codex was used to help analyze the captured packet logs and draft the code change. The change was tested locally on the cascade system before opening this PR.